### PR TITLE
feat(blog): link cross-posted Medium URL from post header

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -94,6 +94,16 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
             ))}
           </ul>
         )}
+        {post.mediumUrl && (
+          <a
+            href={post.mediumUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-5 inline-flex items-center gap-2 rounded-full border border-border/60 px-4 py-2 text-sm font-medium text-muted transition-colors hover:border-accent hover:text-accent dark:border-dark-border dark:text-dark-text-secondary dark:hover:border-dark-accent dark:hover:text-dark-accent"
+          >
+            Originally published on Medium →
+          </a>
+        )}
       </header>
       {post.coverUrl && (
         <div className="relative mb-10 aspect-[16/9] w-full overflow-hidden rounded-xl border border-border/40 bg-surface-alt dark:border-dark-border dark:bg-dark-surface-alt">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -95,14 +95,17 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
           </ul>
         )}
         {post.mediumUrl && (
-          <a
-            href={post.mediumUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="mt-5 inline-flex items-center gap-2 rounded-full border border-border/60 px-4 py-2 text-sm font-medium text-muted transition-colors hover:border-accent hover:text-accent dark:border-dark-border dark:text-dark-text-secondary dark:hover:border-dark-accent dark:hover:text-dark-accent"
-          >
-            Originally published on Medium →
-          </a>
+          <p className="mt-5 text-sm">
+            <a
+              href={post.mediumUrl}
+              target="_blank"
+              rel="noreferrer"
+              style={{ textDecoration: 'underline', textUnderlineOffset: '4px' }}
+              className="font-medium text-accent transition-colors hover:text-accent-hover dark:text-dark-accent dark:hover:text-dark-accent-hover"
+            >
+              Full article at Medium →
+            </a>
+          </p>
         )}
       </header>
       {post.coverUrl && (

--- a/src/content/blog/vibe-coded-mcp-catalog/article.md
+++ b/src/content/blog/vibe-coded-mcp-catalog/article.md
@@ -7,6 +7,7 @@ category: coding
 cover: images/cover.png
 ogImage: images/cover.png
 readingTime: '3 min read'
+mediumUrl: 'https://medium.com/@vreshch/i-vibe-coded-an-mcp-catalog-coding-was-the-easy-part-c4735776d02d'
 tags:
   - mcp
   - vibe-coding

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -17,6 +17,7 @@ export type BlogPostFrontmatter = {
   ogImage?: string;
   tags?: string[];
   readingTime?: string;
+  mediumUrl?: string;
 };
 
 export type BlogPostMeta = {
@@ -31,6 +32,7 @@ export type BlogPostMeta = {
   readingTime: string;
   coverUrl?: string;
   ogImageUrl?: string;
+  mediumUrl?: string;
 };
 
 export type BlogPost = BlogPostMeta & {
@@ -78,6 +80,7 @@ async function readPostFile(slug: string): Promise<BlogPost> {
     readingTime: fm.readingTime ?? calculateReadingTime(content),
     coverUrl,
     ogImageUrl,
+    mediumUrl: fm.mediumUrl,
     content,
   };
 }
@@ -102,6 +105,7 @@ export async function getAllPosts(): Promise<BlogPostMeta[]> {
     readingTime: post.readingTime,
     coverUrl: post.coverUrl,
     ogImageUrl: post.ogImageUrl,
+    mediumUrl: post.mediumUrl,
   }));
   return metas.sort((a, b) => (a.date < b.date ? 1 : -1));
 }


### PR DESCRIPTION
## Summary

- Adds optional `mediumUrl` field to blog post frontmatter (`src/lib/blog.ts`)
- Renders an "Originally published on Medium →" pill in the post header (`src/app/blog/[slug]/page.tsx`), placed under tags and above the cover image
- Wires the MCP catalog post to its Medium URL: https://medium.com/@vreshch/i-vibe-coded-an-mcp-catalog-coding-was-the-easy-part-c4735776d02d

The pill only renders when `mediumUrl` is set, so it's a no-op for posts without a Medium cross-post.

## Visual proofs

Screenshots captured locally at `/tmp/vreshch-pr-screenshots/` — drag them into this PR description to embed:

**Desktop — post header (above the fold)**

<!-- drag /tmp/vreshch-pr-screenshots/blog-post-callout.png here -->

**Mobile — post header**

<!-- drag /tmp/vreshch-pr-screenshots/blog-post-mobile.png here -->

**Desktop — full post (regression check, cover image still renders)**

<!-- drag /tmp/vreshch-pr-screenshots/blog-post-desktop.png here -->

**Blog index — no regression**

<!-- drag /tmp/vreshch-pr-screenshots/blog-index-desktop.png here -->

## Test plan

- [x] \`npm run type-check\` passes
- [x] \`npm run lint\` passes (no warnings)
- [x] \`npm test\` passes (23/23)
- [x] Manual: post page renders pill above cover image (desktop + mobile screenshots above)
- [x] Manual: blog index renders unchanged
- [ ] CI verify pipeline green