### PR TITLE
chore: bump LICENSE year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Volodymyr Vreshch
+Copyright (c) 2026 Volodymyr Vreshch
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Stale year. Bumps Copyright (c) 2024 → 2026. No code change.