### PR TITLE
chore(seo): use summary_large_image twitter card

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,9 +26,10 @@ export const metadata: Metadata = {
     images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'Volodymyr Vreshch' }],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'Volodymyr Vreshch — Software Engineer',
     description: 'Building quality software that matters — for millions.',
+    images: ['/og-image.png'],
   },
 };
 


### PR DESCRIPTION
## Summary

- og:image is already configured at 1200×630 in `src/app/layout.tsx`
- Switch twitter card type from `summary` → `summary_large_image` so X renders the full hero
- Add explicit `images: ['/og-image.png']` to the twitter metadata

## Test plan

- [ ] X (twitter) card validator shows hero
- [ ] LinkedIn / Slack / Discord previews unchanged