### PR TITLE
content(blog): cross-post Agentage Memory launch announcement

### DIFF
--- a/src/content/blog/agentage-memory-is-open/article.md
+++ b/src/content/blog/agentage-memory-is-open/article.md
@@ -1,0 +1,54 @@
+---
+title: 'Agentage Memory is open - join the waitlist'
+subtitle: 'One markdown memory every AI reads and writes - owned by you, hosted in the EU. It is early, we are building in public, and the waitlist is now live.'
+description: 'Agentage Memory is one shared markdown memory every AI reads and writes through a single MCP endpoint - files-first, EU-private, owned by you. Waitlist open.'
+date: 2026-05-31
+category: coding
+tags:
+  - agentage
+  - ai-memory
+  - mcp
+  - waitlist
+  - build-in-public
+---
+
+> I'm building **[Agentage Memory](https://agentage.io)** - one shared memory for every AI. This is the launch announcement; the waitlist is open at **[agentage.io](https://agentage.io)**.
+
+If you work with AI all day, you probably run four or five tools to do it: Claude for one thing, ChatGPT for another, Cursor in the editor, Claude Code in the terminal. Each one opens with a blank slate. None of them knows what the others already learned about you, your project, or the decision you made last week.
+
+So you became the memory. Every time you switch tools you re-paste the architecture, the constraints, the context - fifteen minutes here, twenty there, several times a day, forever. And when a vendor quietly deprecates its built-in memory or wipes it on the next update, the context you spent weeks shaping is simply gone.
+
+Today we are opening the waitlist for the thing we are building to end that: **Agentage Memory**.
+
+## One memory, every AI
+
+Agentage Memory is a single shared memory your AI tools read and write through one MCP endpoint. You connect once - Claude, ChatGPT, Cursor, Claude Code - and from then on they all see the same notes. No per-tool setup, no copy-paste, no plumbing. Connect in minutes and every AI is on the same page.
+
+The canonical copy lives in your own per-tenant store, hosted in the EU. It mirrors to plain markdown files on your machine - files you can open in Obsidian, edit by hand, grep, version, and export anytime. The memory is yours, in a format that outlives any one tool.
+
+## Why build another one
+
+There is no shortage of "AI memory" products. Most fall into two camps, and both have a catch.
+
+Closed-cloud memory keeps your notes in a database you cannot see and do not own. Vendor-built memory - ChatGPT's, Claude's, Cursor's - lives inside one tool and disappears the moment that tool changes its mind.
+
+We are betting on the opposite of both. Four things, together, that nobody else offers as one package:
+
+- **Files you own** - plain markdown on your disk, exportable anytime, zero lock-in.
+- **Every AI** - cross-vendor by default, including a ChatGPT connector, not a walled garden.
+- **Your own store** - a per-tenant copy of your data, not a shared cloud blob.
+- **EU-resident** - your data stays in your region by design.
+
+All at a flat, low price, with no surprise jump from a few dollars to a few hundred. The winner of AI memory will not be a closed cloud database - it will be the open, files-first memory every tool agrees to share.
+
+## It is early - on purpose
+
+Let us be honest about where this is: it is day one. Agentage Memory is pre-release - not in any plugin or community store yet, and not generally available. We are building it in public, shipping in the open, and every integration will land as its own story you can follow: the MCP endpoint, the sync engine, the Obsidian plugin, the CLI.
+
+The waitlist is how we bring people in deliberately, in order, while it is still rough enough that your feedback actually shapes what it becomes.
+
+## Join the waitlist
+
+If you run more than one AI and you are tired of being the memory between them, get on the list at **[agentage.io](https://agentage.io)**. We will reach out as we open spots - and you will be early to a memory that is finally yours.
+
+One memory. Every AI. Owned by you.


### PR DESCRIPTION
Cross-posts the **Agentage Memory** launch announcement to the vreshch.com blog — same text as the post on the agentage Memory site, with links to **[agentage.io](https://agentage.io)** (project + waitlist).

- New post `src/content/blog/agentage-memory-is-open/article.md` (category `coding`).
- Becomes the featured post on `/blog` (dated 2026-05-31, newest).
- `npm run verify` green (type-check + lint + build + 23 tests); prettier clean; `/blog/agentage-memory-is-open` prerenders with the agentage.io links.

_(Date left unquoted to match the existing post's frontmatter so the date-sort test stays green.)_