### PR TITLE
feat(blog): uniform list cards + clickable cover link

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -108,18 +108,37 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
           </p>
         )}
       </header>
-      {post.coverUrl && (
-        <div className="relative mb-10 aspect-[16/9] w-full overflow-hidden rounded-xl border border-border/40 bg-surface-alt dark:border-dark-border dark:bg-dark-surface-alt">
-          <Image
-            src={post.coverUrl}
-            alt={post.title}
-            fill
-            sizes="(min-width: 768px) 768px, 100vw"
-            className="object-cover"
-            priority
-          />
-        </div>
-      )}
+      {post.coverUrl &&
+        (post.coverLink ? (
+          <a
+            href={post.coverLink}
+            aria-label="Join the waitlist at agentage.io"
+            className="group relative mb-10 block aspect-[16/9] w-full overflow-hidden rounded-xl border border-border/40 bg-surface-alt dark:border-dark-border dark:bg-dark-surface-alt"
+          >
+            <Image
+              src={post.coverUrl}
+              alt={post.title}
+              fill
+              sizes="(min-width: 768px) 768px, 100vw"
+              className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+              priority
+            />
+            <span className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-center gap-2 bg-gradient-to-t from-black/75 to-transparent p-4 text-sm font-medium text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+              Join the waitlist at agentage.io →
+            </span>
+          </a>
+        ) : (
+          <div className="relative mb-10 aspect-[16/9] w-full overflow-hidden rounded-xl border border-border/40 bg-surface-alt dark:border-dark-border dark:bg-dark-surface-alt">
+            <Image
+              src={post.coverUrl}
+              alt={post.title}
+              fill
+              sizes="(min-width: 768px) 768px, 100vw"
+              className="object-cover"
+              priority
+            />
+          </div>
+        ))}
       <div className="prose-blog">
         <BlogMdx source={post.content} />
       </div>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -11,19 +11,7 @@ export const metadata: Metadata = {
     'Mostly on agents, MCP, and the craft of shipping — with detours into family and hobby.',
 };
 
-function GridCoverFrame({ url, alt, sizes }: { url?: string; alt: string; sizes: string }) {
-  return (
-    <div className="relative aspect-[16/9] w-full overflow-hidden bg-surface-alt dark:bg-dark-surface-alt">
-      {url ? (
-        <Image src={url} alt={alt} fill sizes={sizes} className="object-cover" />
-      ) : (
-        <div className="h-full w-full bg-gradient-to-br from-surface to-surface-alt dark:from-dark-surface dark:to-dark-surface-alt" />
-      )}
-    </div>
-  );
-}
-
-function FeaturedCard({ post }: { post: BlogPostMeta }) {
+function PostCard({ post }: { post: BlogPostMeta }) {
   return (
     <Link href={`/blog/${post.slug}`} className="block">
       <Card hover="lift" padding="none" className="overflow-hidden">
@@ -45,9 +33,6 @@ function FeaturedCard({ post }: { post: BlogPostMeta }) {
           </div>
           <div className="flex flex-col justify-center p-6 md:p-8">
             <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted dark:text-dark-text-secondary">
-              <span className="inline-flex items-center rounded-full bg-accent/10 px-2.5 py-0.5 text-[0.6875rem] font-medium uppercase tracking-wide text-accent dark:bg-dark-accent/15 dark:text-dark-accent">
-                Featured
-              </span>
               <time dateTime={post.date}>{formatPostDate(post.date)}</time>
               <span aria-hidden="true">·</span>
               <span>{post.readingTime}</span>
@@ -67,38 +52,8 @@ function FeaturedCard({ post }: { post: BlogPostMeta }) {
   );
 }
 
-function GridCard({ post }: { post: BlogPostMeta }) {
-  return (
-    <Link href={`/blog/${post.slug}`} className="flex w-full">
-      <Card hover="lift" padding="none" className="flex w-full flex-col overflow-hidden">
-        <GridCoverFrame
-          url={post.coverUrl}
-          alt={post.title}
-          sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
-        />
-        <div className="flex flex-1 flex-col p-6">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted dark:text-dark-text-secondary">
-            <time dateTime={post.date}>{formatPostDate(post.date)}</time>
-            <span aria-hidden="true">·</span>
-            <span>{post.readingTime}</span>
-          </div>
-          <h2 className="mb-2 mt-2 text-lg font-medium leading-snug text-heading dark:text-dark-text">
-            {post.title}
-          </h2>
-          {post.subtitle && (
-            <p className="line-clamp-3 text-sm text-muted dark:text-dark-text-secondary">
-              {post.subtitle}
-            </p>
-          )}
-        </div>
-      </Card>
-    </Link>
-  );
-}
-
 export default async function BlogIndexPage() {
   const posts = await getAllPosts();
-  const [featured, ...rest] = posts;
 
   return (
     <div>
@@ -111,18 +66,13 @@ export default async function BlogIndexPage() {
         {posts.length === 0 ? (
           <p className="text-muted dark:text-dark-text-secondary">No posts yet.</p>
         ) : (
-          <div className="flex flex-col gap-10">
-            {featured && <FeaturedCard post={featured} />}
-            {rest.length > 0 && (
-              <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                {rest.map((post) => (
-                  <li key={post.slug} className="flex">
-                    <GridCard post={post} />
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
+          <ul className="flex flex-col gap-8">
+            {posts.map((post) => (
+              <li key={post.slug}>
+                <PostCard post={post} />
+              </li>
+            ))}
+          </ul>
         )}
       </div>
     </div>

--- a/src/content/blog/agentage-memory-is-open/article.md
+++ b/src/content/blog/agentage-memory-is-open/article.md
@@ -6,6 +6,7 @@ date: 2026-05-31
 category: coding
 cover: images/cover.png
 ogImage: images/cover.png
+coverLink: 'https://agentage.io/#waitlist'
 tags:
   - agentage
   - ai-memory

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -18,6 +18,7 @@ export type BlogPostFrontmatter = {
   tags?: string[];
   readingTime?: string;
   mediumUrl?: string;
+  coverLink?: string;
 };
 
 export type BlogPostMeta = {
@@ -33,6 +34,7 @@ export type BlogPostMeta = {
   coverUrl?: string;
   ogImageUrl?: string;
   mediumUrl?: string;
+  coverLink?: string;
 };
 
 export type BlogPost = BlogPostMeta & {
@@ -81,6 +83,7 @@ async function readPostFile(slug: string): Promise<BlogPost> {
     coverUrl,
     ogImageUrl,
     mediumUrl: fm.mediumUrl,
+    coverLink: fm.coverLink,
     content,
   };
 }


### PR DESCRIPTION
Two blog tweaks:

1. **Uniform list cards** — every post in `/blog` now renders as the same horizontal card (cover left, text right). Dropped the featured-vs-grid split and the "Featured" badge so posts are aligned/consistent.
2. **Clickable cover** — new optional `coverLink` frontmatter; when set, the post-page cover is a link (with a hover CTA). The Agentage Memory post's cover → `https://agentage.io/#waitlist`.

`npm run verify` green (23 tests); prerendered HTML confirms the cover `href` and 0 "Featured" badges. (Landing-side `#waitlist` focus handled in a separate agentage PR.)