### PR TITLE
fix(ci): escape commit message in deploy summary step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,13 +180,17 @@ jobs:
     steps:
       - name: 📊 Generate summary
         uses: actions/github-script@v9
+        env:
+          # Pass via env, not string-interpolation: a backtick (or any special
+          # char) in the commit message would otherwise break the inline script.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         with:
           script: |
             const buildResult = '${{ needs.build-and-push.result }}';
             const deployResult = '${{ needs.deploy.result }}';
             const imageTag = '${{ needs.build-and-push.outputs.image-tag }}';
             const commitSha = '${{ github.sha }}';
-            const commitMessage = `${{ github.event.head_commit.message }}` || 'Manual deployment';
+            const commitMessage = process.env.COMMIT_MESSAGE || 'Manual deployment';
             const eventName = '${{ github.event_name }}';
             const triggerType = eventName === 'workflow_dispatch' ? 'Manual' : 'Automatic (push)';
 


### PR DESCRIPTION
The deploy "Generate summary" step interpolated the raw commit message into a `github-script` **template literal** — a backtick in the message (e.g. PR #113's ``coverLink``) prematurely closed the literal → `SyntaxError: Unexpected identifier`, failing the run (the deploy itself still succeeded). Also a latent script-injection vector.

Fix: pass the message via `env.COMMIT_MESSAGE` and read `process.env.COMMIT_MESSAGE` (GitHub's documented safe pattern) instead of inlining it into the script source.