### PR TITLE
feat: replace favicon with centered amber V on navy

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,5 +1,4 @@
 <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
   <rect width="32" height="32" rx="7" fill="#1e3a5f" />
-  <path d="M8 6 L16 22 L24 6" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M10 27 A9 9 0 0 0 22 27" fill="none" stroke="#f59e0b" stroke-width="2.5" stroke-linecap="round" />
+  <path d="M8 10 L16 22 L24 10" fill="none" stroke="#f59e0b" stroke-width="3.8" stroke-linejoin="round" stroke-linecap="round" />
 </svg>


### PR DESCRIPTION
## What
Replaces the browser-tab favicon (`src/app/icon.svg`).

**Before:** thin white V + amber smile arc on navy — reads as faint, busy scribbles at 16px in the Chrome tab.
**After:** single bolder amber V on the navy tile — higher contrast, legible at favicon size.

```
<svg viewBox="0 0 32 32">
  <rect width="32" height="32" rx="7" fill="#1e3a5f" />
  <path d="M8 10 L16 22 L24 10" stroke="#f59e0b" stroke-width="3.8" .../>
</svg>
```

Selected from a multi-option review (geometry + color/gradient variants compared at 16/32/64px and in mock light/dark tab strips).

## Verify
Open the preview → check the browser-tab icon renders as a clean amber V on navy at small size.