### PR TITLE
fix: widen blog post page to match home width

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -53,7 +53,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
   const sourceUrl = `${REPO_URL}/blob/${REPO_BRANCH}/src/content/blog/${post.slug}/article.md`;
 
   return (
-    <article className="mx-auto max-w-3xl px-6 pb-16 pt-12 md:pb-24 md:pt-16">
+    <article className="mx-auto max-w-5xl px-6 pb-16 pt-12 md:pb-24 md:pt-16">
       <Link
         href="/blog"
         className="mb-8 inline-flex items-center gap-2 text-sm text-muted transition-colors hover:text-heading dark:text-dark-text-secondary dark:hover:text-dark-text"
@@ -119,7 +119,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
               src={post.coverUrl}
               alt={post.title}
               fill
-              sizes="(min-width: 768px) 768px, 100vw"
+              sizes="(min-width: 1024px) 1024px, 100vw"
               className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
               priority
             />
@@ -133,7 +133,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
               src={post.coverUrl}
               alt={post.title}
               fill
-              sizes="(min-width: 768px) 768px, 100vw"
+              sizes="(min-width: 1024px) 1024px, 100vw"
               className="object-cover"
               priority
             />


### PR DESCRIPTION
## What
Blog post pages (`/blog/[slug]`) used `max-w-3xl` while the home page and blog list use `max-w-5xl`. Widened the article container to `max-w-5xl` so the post page matches the rest of the site.

Reported on: https://vreshch.com/blog/vibe-coded-mcp-catalog (narrower than https://vreshch.com/).

## Changes
- `src/app/blog/[slug]/page.tsx`: article `max-w-3xl` → `max-w-5xl`
- Updated cover-image `sizes` hint `768px` → `1024px` to match new column width

## Verified
- `npm run type-check` ✅
- `npm run build` ✅ (both blog posts prerender)

## Verify (human)
Open the preview, visit a blog post, confirm content width now matches the home page.