### PR TITLE
fix(seo): unique descriptions, canonicals, and OG per interior route

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -9,6 +9,14 @@ export const metadata: Metadata = {
   title: 'Blog',
   description:
     'Mostly on agents, MCP, and the craft of shipping — with detours into family and hobby.',
+  alternates: { canonical: '/blog' },
+  openGraph: {
+    title: 'Blog',
+    description:
+      'Mostly on agents, MCP, and the craft of shipping - with detours into family and hobby.',
+    url: '/blog',
+    siteName: 'Volodymyr Vreshch',
+  },
 };
 
 function PostCard({ post }: { post: BlogPostMeta }) {

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -6,6 +6,16 @@ import { ContactForm } from '@/components/contact-form';
 
 export const metadata: Metadata = {
   title: 'Contacts',
+  description:
+    'Get in touch with Volodymyr Vreshch by email or via LinkedIn, GitHub, Facebook, and Instagram, or send a message directly through the contact form.',
+  alternates: { canonical: '/contacts' },
+  openGraph: {
+    title: 'Contacts',
+    description:
+      'Get in touch with Volodymyr Vreshch by email, LinkedIn, GitHub, and social, or send a message through the contact form.',
+    url: '/contacts',
+    siteName: 'Volodymyr Vreshch',
+  },
 };
 
 const contacts = [

--- a/src/app/interests/page.tsx
+++ b/src/app/interests/page.tsx
@@ -4,6 +4,16 @@ import { PageHeader } from '@/components/page-header';
 
 export const metadata: Metadata = {
   title: 'Interests',
+  description:
+    'What Volodymyr Vreshch focuses on and builds: AI agents, the Model Context Protocol, full-stack TypeScript, developer experience, and open source at scale.',
+  alternates: { canonical: '/interests' },
+  openGraph: {
+    title: 'Interests',
+    description:
+      'AI agents, the Model Context Protocol, full-stack TypeScript, developer experience, and open source at scale.',
+    url: '/interests',
+    siteName: 'Volodymyr Vreshch',
+  },
 };
 
 export default function InterestsPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,17 @@ import Link from 'next/link';
 import { Card } from '@/components/card';
 
 export const metadata: Metadata = {
-  title: 'Volodymyr Vreshch - Home',
+  title: { absolute: 'Volodymyr Vreshch - Software Engineer' },
+  description:
+    'Volodymyr Vreshch, Senior Software Engineer at Microsoft with 10+ years shipping software at scale, building AI agents, MCP tooling, and open source.',
+  alternates: { canonical: '/' },
+  openGraph: {
+    title: 'Volodymyr Vreshch - Software Engineer',
+    description:
+      'Senior Software Engineer at Microsoft with 10+ years shipping software at scale, building AI agents, MCP tooling, and open source.',
+    url: '/',
+    siteName: 'Volodymyr Vreshch',
+  },
 };
 
 export default function HomePage() {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -7,6 +7,16 @@ import { CrystalViewDemo } from '@/components/crystalview-demo';
 
 export const metadata: Metadata = {
   title: 'Projects',
+  description:
+    'Projects by Volodymyr Vreshch: Agentage Memory and its open source ecosystem, mcpxhub.io, crystallography.io, plus chemistry tools and interactive demos.',
+  alternates: { canonical: '/projects' },
+  openGraph: {
+    title: 'Projects',
+    description:
+      'Agentage Memory and its open source ecosystem, mcpxhub.io, crystallography.io, plus chemistry tools and interactive demos.',
+    url: '/projects',
+    siteName: 'Volodymyr Vreshch',
+  },
 };
 
 const libraries = [


### PR DESCRIPTION
## Why

The interior App Router pages (home, `/projects`, `/interests`, `/contacts`, `/blog`) exported a `metadata` object with only a `title` (and, for blog, a `description`). Because they omitted `description` and `openGraph`, they inherited the root layout's values, so:

- Every page shared the homepage's meta description.
- Every page inherited the root `og:title` / `og:url` - so sharing `/projects` (or any interior route) previewed as the homepage with the wrong URL.
- None of these routes set a self-canonical (only blog posts did).

The home `title` (`'Volodymyr Vreshch - Home'`) also rendered redundantly through the root template as `Volodymyr Vreshch - Home | Volodymyr Vreshch`, and "Home" is a low-value SERP token.

## Change

For each of home, `/projects`, `/interests`, `/contacts`, `/blog`:

- Added a unique, content-accurate `description` (~110-160 chars).
- Added `alternates: { canonical: '<path>' }` (relative, resolves against `metadataBase` in `layout.tsx`).
- Added a page-specific `openGraph: { title, description, url: '<path>', siteName }` so each stops inheriting the homepage OG title/URL. `siteName` is included explicitly (reusing the layout value) so it is not dropped once the child sets its own `openGraph`. Root `og:image` / `locale` still apply for keys the child does not override.

Home page: changed the title to `title: { absolute: 'Volodymyr Vreshch - Software Engineer' }` to bypass the template (avoids the doubled site name) and dropped the "Home" token. Chose `{ absolute }` over a bare title so the SERP shows the descriptive role phrase and matches the layout `default`.

No Tier-3 work (RSS, sitemap lastmod, manifest/apple-icon) in this PR. `package-lock.json` untouched (source-only).

## Verify

`npm run verify` (type-check + lint + build + test) passes: build clean, 23/23 tests green.
