### PR TITLE
feat(interests): AI-first visual rebuild with receipts and timeline

### DIFF
--- a/src/app/interests/page.tsx
+++ b/src/app/interests/page.tsx
@@ -6,18 +6,18 @@ import { ExternalLink } from '@/components/interests/external-link';
 import { FocusSection } from '@/components/interests/focus-section';
 import { TimelineRow } from '@/components/interests/timeline-row';
 import { ScrollReveal } from '@/components/interests/scroll-reveal';
-import { TIMELINE, HOBBIES, PROFILE_LINKS } from '@/lib/interests-data';
+import { TIMELINE, HOBBIES, INTERESTS, PROFILE_LINKS } from '@/lib/interests-data';
 import { getAllPosts } from '@/lib/blog';
 
 export const metadata: Metadata = {
   title: 'Interests',
   description:
-    'Volodymyr Vreshch: inorganic-chemistry PhD turned platform engineer. Currently exploring AI agents, MCP, and how AI should remember. Track record, open-source work, and links.',
+    'Volodymyr Vreshch: platform engineer with a PhD, exploring AI agents, the Model Context Protocol, AI memory, and open source. Interests, track record, and links.',
   alternates: { canonical: '/interests' },
   openGraph: {
     title: 'Interests',
     description:
-      'Inorganic-chemistry PhD turned platform engineer. Exploring AI agents, MCP, and how AI should remember.',
+      'Platform engineer exploring AI agents, the Model Context Protocol, AI memory, and open source.',
     url: '/interests',
     siteName: 'Volodymyr Vreshch',
   },
@@ -30,10 +30,13 @@ export default async function InterestsPage() {
 
   return (
     <div>
-      <PageHeader title="About" description="A little more about me, my work, and what I explore." />
+      <PageHeader
+        title="Interests"
+        description="What I explore, build, and keep coming back to."
+      />
 
       <div className="mx-auto max-w-5xl px-6 pb-16 md:pb-24">
-        <section className="mb-16 flex max-w-3xl items-start gap-5">
+        <section className="mb-10 flex max-w-3xl items-start gap-5">
           <Image
             src="/images/profile.jpeg"
             alt="Volodymyr Vreshch"
@@ -42,10 +45,23 @@ export default async function InterestsPage() {
             className="hidden h-16 w-16 flex-shrink-0 rounded-full object-cover ring-1 ring-border/70 sm:block dark:ring-dark-border"
           />
           <p className="text-base leading-relaxed text-muted dark:text-dark-text-secondary md:text-lg">
-            I&apos;m an inorganic-chemistry PhD turned platform engineer, now a Senior Software
-            Engineer at Microsoft. Lately I&apos;ve been exploring AI agents, the Model Context
-            Protocol, and how AI should remember. Based in Prague.
+            I&apos;m a platform engineer with a PhD, now a Senior Software Engineer at Microsoft.
+            Lately I&apos;ve been exploring AI agents, the Model Context Protocol, and how AI should
+            remember. Based in Prague.
           </p>
+        </section>
+
+        <section className="mb-16 max-w-3xl">
+          <ul className="flex flex-wrap gap-2.5">
+            {INTERESTS.map((interest) => (
+              <li
+                key={interest}
+                className="rounded-full border border-border/70 bg-surface-alt px-3.5 py-1.5 text-sm text-muted dark:border-dark-border dark:bg-dark-surface-alt dark:text-dark-text-secondary"
+              >
+                {interest}
+              </li>
+            ))}
+          </ul>
         </section>
 
         <FocusSection writingCover={writingCover ? { src: writingCover, alt: latest?.title ?? 'Latest essay', width: 1200, height: 630 } : undefined} />

--- a/src/app/interests/page.tsx
+++ b/src/app/interests/page.tsx
@@ -30,10 +30,7 @@ export default async function InterestsPage() {
 
   return (
     <div>
-      <PageHeader
-        title="Interests"
-        description="What I explore, build, and keep coming back to."
-      />
+      <PageHeader title="Interests" description="What I explore, build, and keep coming back to." />
 
       <div className="mx-auto max-w-5xl px-6 pb-16 md:pb-24">
         <section className="mb-10 flex max-w-3xl items-start gap-5">
@@ -64,7 +61,18 @@ export default async function InterestsPage() {
           </ul>
         </section>
 
-        <FocusSection writingCover={writingCover ? { src: writingCover, alt: latest?.title ?? 'Latest essay', width: 1200, height: 630 } : undefined} />
+        <FocusSection
+          writingCover={
+            writingCover
+              ? {
+                  src: writingCover,
+                  alt: latest?.title ?? 'Latest essay',
+                  width: 1200,
+                  height: 630,
+                }
+              : undefined
+          }
+        />
 
         <ScrollReveal as="section" className="mb-16">
           <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">

--- a/src/app/interests/page.tsx
+++ b/src/app/interests/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from 'next';
+import Image from 'next/image';
 import { Card } from '@/components/card';
 import { PageHeader } from '@/components/page-header';
 import { ExternalLink } from '@/components/interests/external-link';
-import { NowThreadCard } from '@/components/interests/now-thread-card';
+import { FocusSection } from '@/components/interests/focus-section';
 import { TimelineRow } from '@/components/interests/timeline-row';
-import { NOW_THREADS, TIMELINE, HOBBIES, PROFILE_LINKS } from '@/lib/interests-data';
+import { ScrollReveal } from '@/components/interests/scroll-reveal';
+import { TIMELINE, HOBBIES, PROFILE_LINKS } from '@/lib/interests-data';
+import { getAllPosts } from '@/lib/blog';
 
 export const metadata: Metadata = {
   title: 'Interests',
@@ -20,13 +23,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default function InterestsPage() {
+export default async function InterestsPage() {
+  const posts = await getAllPosts();
+  const latest = posts.find((p) => p.thumbnailUrl ?? p.coverUrl);
+  const writingCover = latest?.thumbnailUrl ?? latest?.coverUrl;
+
   return (
     <div>
       <PageHeader title="About" description="A little more about me, my work, and what I explore." />
 
       <div className="mx-auto max-w-5xl px-6 pb-16 md:pb-24">
-        <section className="mb-16 max-w-3xl">
+        <section className="mb-16 flex max-w-3xl items-start gap-5">
+          <Image
+            src="/images/profile.jpeg"
+            alt="Volodymyr Vreshch"
+            width={72}
+            height={72}
+            className="hidden h-16 w-16 flex-shrink-0 rounded-full object-cover ring-1 ring-border/70 sm:block dark:ring-dark-border"
+          />
           <p className="text-base leading-relaxed text-muted dark:text-dark-text-secondary md:text-lg">
             I&apos;m an inorganic-chemistry PhD turned platform engineer, now a Senior Software
             Engineer at Microsoft. Lately I&apos;ve been exploring AI agents, the Model Context
@@ -34,29 +48,22 @@ export default function InterestsPage() {
           </p>
         </section>
 
-        <section className="mb-16">
-          <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">Now</h2>
-          <div className="grid gap-6 md:grid-cols-3">
-            {NOW_THREADS.map((thread) => (
-              <NowThreadCard key={thread.title} thread={thread} />
-            ))}
-          </div>
-        </section>
+        <FocusSection writingCover={writingCover ? { src: writingCover, alt: latest?.title ?? 'Latest essay', width: 1200, height: 630 } : undefined} />
 
-        <section className="mb-16">
+        <ScrollReveal as="section" className="mb-16">
           <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">
             Track record
           </h2>
           <Card className="md:p-10">
-            <div className="space-y-8">
+            <div className="space-y-6">
               {TIMELINE.map((entry) => (
                 <TimelineRow key={entry.role} entry={entry} />
               ))}
             </div>
           </Card>
-        </section>
+        </ScrollReveal>
 
-        <section className="mb-16 max-w-3xl">
+        <ScrollReveal as="section" className="mb-16 max-w-3xl">
           <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">
             Beyond the keyboard
           </h2>
@@ -68,9 +75,9 @@ export default function InterestsPage() {
               </li>
             ))}
           </ul>
-        </section>
+        </ScrollReveal>
 
-        <section>
+        <ScrollReveal as="section">
           <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">Find me</h2>
           <div className="flex flex-wrap gap-x-6 gap-y-3">
             {PROFILE_LINKS.map((link) => (
@@ -79,7 +86,7 @@ export default function InterestsPage() {
               </ExternalLink>
             ))}
           </div>
-        </section>
+        </ScrollReveal>
       </div>
     </div>
   );

--- a/src/app/interests/page.tsx
+++ b/src/app/interests/page.tsx
@@ -1,16 +1,20 @@
 import type { Metadata } from 'next';
 import { Card } from '@/components/card';
 import { PageHeader } from '@/components/page-header';
+import { ExternalLink } from '@/components/interests/external-link';
+import { NowThreadCard } from '@/components/interests/now-thread-card';
+import { TimelineRow } from '@/components/interests/timeline-row';
+import { NOW_THREADS, TIMELINE, HOBBIES, PROFILE_LINKS } from '@/lib/interests-data';
 
 export const metadata: Metadata = {
   title: 'Interests',
   description:
-    'What Volodymyr Vreshch focuses on and builds: AI agents, the Model Context Protocol, full-stack TypeScript, developer experience, and open source at scale.',
+    'Volodymyr Vreshch: inorganic-chemistry PhD turned platform engineer. Currently exploring AI agents, MCP, and how AI should remember. Track record, open-source work, and links.',
   alternates: { canonical: '/interests' },
   openGraph: {
     title: 'Interests',
     description:
-      'AI agents, the Model Context Protocol, full-stack TypeScript, developer experience, and open source at scale.',
+      'Inorganic-chemistry PhD turned platform engineer. Exploring AI agents, MCP, and how AI should remember.',
     url: '/interests',
     siteName: 'Volodymyr Vreshch',
   },
@@ -19,107 +23,61 @@ export const metadata: Metadata = {
 export default function InterestsPage() {
   return (
     <div>
-      <PageHeader
-        title="Interests"
-        description="What I focus on, what I build, and what drives me."
-      />
+      <PageHeader title="About" description="A little more about me, my work, and what I explore." />
 
       <div className="mx-auto max-w-5xl px-6 pb-16 md:pb-24">
-        {/* Areas of Interest */}
-        <section className="mb-16">
-          <Card>
-            <h2 className="mb-6 text-xl font-medium text-heading dark:text-dark-text">
-              Areas of Interest
-            </h2>
-            <ul className="space-y-3 text-sm leading-relaxed text-muted dark:text-dark-text-secondary md:text-base">
-              {[
-                'AI Agents, LLMs, and agent orchestration platforms',
-                'Model Context Protocol (MCP) and tool ecosystems for AI',
-                'Full-stack web development: React, Next.js, Node.js, TypeScript',
-                'Developer experience, engineering productivity, and development flow optimization',
-                'Infrastructure as Code, CI/CD pipelines, and cloud architecture',
-                'Open-source software and building tools that serve millions',
-              ].map((item) => (
-                <li key={item} className="flex items-start gap-3">
-                  <span className="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-muted/50 dark:bg-dark-text-secondary/50" />
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </Card>
+        <section className="mb-16 max-w-3xl">
+          <p className="text-base leading-relaxed text-muted dark:text-dark-text-secondary md:text-lg">
+            I&apos;m an inorganic-chemistry PhD turned platform engineer, now a Senior Software
+            Engineer at Microsoft. Lately I&apos;ve been exploring AI agents, the Model Context
+            Protocol, and how AI should remember. Based in Prague.
+          </p>
         </section>
 
-        {/* Tech Stack */}
         <section className="mb-16">
-          <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">Tech Stack</h2>
-          <p className="mb-6 text-sm leading-relaxed text-muted dark:text-dark-text-secondary md:text-base">
-            10+ years building enterprise products with millions of users — from frontend interfaces
-            to backend services, infrastructure, and AI-powered tooling.
-          </p>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {[
-              'AI Agents, MCP, LLM Orchestration',
-              'OpenAI, Anthropic, Google AI',
-              'TypeScript, C#, Python',
-              'React, Next.js, Vite',
-              'Node.js, Express, MongoDB',
-              'Electron, React Native, Expo',
-              'Azure, Google Cloud, AWS',
-              'Docker, Terraform, CI/CD',
-              'Supabase, CosmosDB, Redis',
-              'Tailwind CSS, Radix UI',
-              'TDD, Playwright, Jest',
-              'Git, GitHub Actions, Traefik',
-            ].map((skill) => (
-              <Card key={skill} padding="compact">
-                <p className="text-sm font-medium text-heading dark:text-dark-text">{skill}</p>
-              </Card>
+          <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">Now</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {NOW_THREADS.map((thread) => (
+              <NowThreadCard key={thread.title} thread={thread} />
             ))}
           </div>
         </section>
 
-        {/* What I'm Building */}
-        <section>
+        <section className="mb-16">
           <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">
-            What I&apos;m Building
+            Track record
           </h2>
-          <div className="grid gap-6 md:grid-cols-2">
-            <Card>
-              <h3 className="mb-2 text-base font-medium text-heading dark:text-dark-text">
-                AI Agent Platform
-              </h3>
-              <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-                Building an orchestration platform for AI agents — manage, execute, and distribute
-                agents across desktop, web, mobile, and CLI.
-              </p>
-            </Card>
-            <Card>
-              <h3 className="mb-2 text-base font-medium text-heading dark:text-dark-text">
-                MCP Catalog
-              </h3>
-              <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-                Central hub for discovering and cataloging Model Context Protocol servers — helping
-                developers find the right tools for their AI workflows.
-              </p>
-            </Card>
-            <Card>
-              <h3 className="mb-2 text-base font-medium text-heading dark:text-dark-text">
-                Enterprise at Microsoft
-              </h3>
-              <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-                Leading frontend development on products used by millions. Focused on engineering
-                productivity, team enablement, and shipping at scale.
-              </p>
-            </Card>
-            <Card>
-              <h3 className="mb-2 text-base font-medium text-heading dark:text-dark-text">
-                Open Source
-              </h3>
-              <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-                Maintaining open-source libraries and tools — from crystal structure search
-                applications to developer utilities and infrastructure automation.
-              </p>
-            </Card>
+          <Card className="md:p-10">
+            <div className="space-y-8">
+              {TIMELINE.map((entry) => (
+                <TimelineRow key={entry.role} entry={entry} />
+              ))}
+            </div>
+          </Card>
+        </section>
+
+        <section className="mb-16 max-w-3xl">
+          <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">
+            Beyond the keyboard
+          </h2>
+          <ul className="space-y-3 text-sm leading-relaxed text-muted dark:text-dark-text-secondary md:text-base">
+            {HOBBIES.map((hobby) => (
+              <li key={hobby} className="flex items-start gap-3">
+                <span className="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-muted/50 dark:bg-dark-text-secondary/50" />
+                {hobby}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">Find me</h2>
+          <div className="flex flex-wrap gap-x-6 gap-y-3">
+            {PROFILE_LINKS.map((link) => (
+              <ExternalLink key={link.href} href={link.href}>
+                {link.label}
+              </ExternalLink>
+            ))}
           </div>
         </section>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -193,6 +193,15 @@ export default async function HomePage() {
                   Earlier: Software Engineer at GlobalLogic, and academic research - Ph.D. in
                   Inorganic Chemistry (Kyiv) with post-docs in the USA and France.
                 </p>
+                <p>
+                  <Link
+                    href="/interests"
+                    className="inline-flex items-center gap-1 font-medium text-accent transition-colors hover:text-accent-hover dark:text-dark-accent dark:hover:text-dark-accent-hover"
+                  >
+                    More about me
+                    <span aria-hidden>&rarr;</span>
+                  </Link>
+                </p>
               </div>
             </div>
           </Card>

--- a/src/components/interests/external-link.tsx
+++ b/src/components/interests/external-link.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+export function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
+  const isInternal = href.startsWith('/');
+
+  if (isInternal) {
+    return (
+      <Link
+        href={href}
+        className="font-medium text-accent transition-colors hover:text-accent-hover dark:text-dark-accent dark:hover:text-dark-accent-hover"
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener"
+      className="font-medium text-accent transition-colors hover:text-accent-hover dark:text-dark-accent dark:hover:text-dark-accent-hover"
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/interests/focus-section.tsx
+++ b/src/components/interests/focus-section.tsx
@@ -26,12 +26,12 @@ export function FocusSection({ writingCover }: { writingCover?: Cover }) {
         </p>
       </ScrollReveal>
 
-      <div className="mt-10 grid gap-6 md:grid-cols-2">
-        <ScrollReveal className="md:row-span-2">
-          <NowThreadCard thread={aiMemory} featured />
+      <div className="mt-10 grid gap-6 md:grid-cols-3">
+        <ScrollReveal>
+          <NowThreadCard thread={aiMemory} />
         </ScrollReveal>
         <ScrollReveal delayMs={80}>
-          <NowThreadCard thread={mcp} featured />
+          <NowThreadCard thread={mcp} />
         </ScrollReveal>
         <ScrollReveal delayMs={160}>
           <NowThreadCard thread={writing} coverImage={writingCover} />

--- a/src/components/interests/focus-section.tsx
+++ b/src/components/interests/focus-section.tsx
@@ -1,0 +1,46 @@
+import { NowThreadCard } from './now-thread-card';
+import { FocusStats } from './focus-stats';
+import { ScrollReveal } from './scroll-reveal';
+import { NOW_THREADS, FOCUS_STATS } from '@/lib/interests-data';
+
+type Cover = { src: string; alt: string; width: number; height: number };
+
+export function FocusSection({ writingCover }: { writingCover?: Cover }) {
+  const [aiMemory, mcp, writing] = NOW_THREADS;
+
+  return (
+    <section className="mb-20 md:mb-28">
+      <ScrollReveal>
+        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-accent dark:text-dark-accent">
+          Current focus / AI
+        </p>
+        <h2 className="max-w-3xl text-3xl font-medium leading-[1.1] tracking-tight text-heading dark:text-dark-text md:text-5xl">
+          Building the memory and plumbing that lets{' '}
+          <span className="bg-gradient-to-r from-accent to-primary-light bg-clip-text text-transparent dark:from-dark-accent dark:to-primary-light">
+            AI actually remember
+          </span>
+          .
+        </h2>
+        <p className="mt-4 max-w-2xl text-base leading-relaxed text-muted dark:text-dark-text-secondary md:text-lg">
+          Three open threads, all pointed at the same idea: AI you can extend, inspect, and own.
+        </p>
+      </ScrollReveal>
+
+      <div className="mt-10 grid gap-6 md:grid-cols-2">
+        <ScrollReveal className="md:row-span-2">
+          <NowThreadCard thread={aiMemory} featured />
+        </ScrollReveal>
+        <ScrollReveal delayMs={80}>
+          <NowThreadCard thread={mcp} featured />
+        </ScrollReveal>
+        <ScrollReveal delayMs={160}>
+          <NowThreadCard thread={writing} coverImage={writingCover} />
+        </ScrollReveal>
+      </div>
+
+      <ScrollReveal delayMs={80} className="mt-10">
+        <FocusStats stats={FOCUS_STATS} />
+      </ScrollReveal>
+    </section>
+  );
+}

--- a/src/components/interests/focus-stats.tsx
+++ b/src/components/interests/focus-stats.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import type { FocusStat } from '@/lib/interests-data';
+
+const DURATION_MS = 1100;
+
+function useCountUp(target: number, active: boolean): number {
+  const [value, setValue] = useState(0);
+  useEffect(() => {
+    if (!active) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setValue(target);
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / DURATION_MS);
+      const eased = 1 - Math.pow(1 - t, 3);
+      setValue(Math.round(eased * target));
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [target, active]);
+  return value;
+}
+
+function StatCell({ stat, active }: { stat: FocusStat; active: boolean }) {
+  const value = useCountUp(stat.value, active);
+  const external = !stat.href.startsWith('/');
+  const linkProps = external ? { target: '_blank', rel: 'noopener' } : {};
+  return (
+    <Link
+      href={stat.href}
+      {...linkProps}
+      className="group flex flex-col gap-1 rounded-xl px-1 py-2 transition-colors hover:bg-surface-alt dark:hover:bg-dark-surface-alt"
+    >
+      <span className="text-3xl font-semibold tabular-nums tracking-tight text-heading dark:text-dark-text md:text-4xl">
+        {stat.prefix}
+        {value}
+        {stat.suffix}
+      </span>
+      <span className="text-sm text-muted dark:text-dark-text-secondary">{stat.label}</span>
+      <span className="text-xs text-accent transition-colors group-hover:text-accent-hover dark:text-dark-accent">
+        {stat.source} &rarr;
+      </span>
+    </Link>
+  );
+}
+
+export function FocusStats({ stats }: { stats: FocusStat[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setActive(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.4 }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className="grid grid-cols-2 gap-4 md:grid-cols-4">
+      {stats.map((stat) => (
+        <StatCell key={stat.label} stat={stat} active={active} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/interests/now-thread-card.tsx
+++ b/src/components/interests/now-thread-card.tsx
@@ -1,27 +1,65 @@
+import Image from 'next/image';
 import { Fragment } from 'react';
 import { Card } from '@/components/card';
 import { ExternalLink } from './external-link';
 import type { NowThread } from '@/lib/interests-data';
 
-export function NowThreadCard({ thread }: { thread: NowThread }) {
+type ThreadImage = { src: string; alt: string; width: number; height: number };
+
+export function NowThreadCard({
+  thread,
+  featured = false,
+  coverImage,
+}: {
+  thread: NowThread;
+  featured?: boolean;
+  coverImage?: ThreadImage;
+}) {
+  const image = thread.image ?? coverImage;
+
   return (
-    <Card className="flex h-full flex-col">
-      <h3 className="mb-2 text-base font-medium text-heading dark:text-dark-text">{thread.title}</h3>
-      <p className="mb-4 flex-1 text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-        {thread.body}
-      </p>
-      <p className="text-sm">
-        {thread.links.map((link, index) => (
-          <Fragment key={link.href}>
-            {index > 0 && (
-              <span className="text-muted dark:text-dark-text-secondary" aria-hidden>
-                {' · '}
-              </span>
-            )}
-            <ExternalLink href={link.href}>{link.label}</ExternalLink>
-          </Fragment>
-        ))}
-      </p>
+    <Card
+      padding="none"
+      hover="lift"
+      className="group flex h-full flex-col overflow-hidden ring-1 ring-border/60 dark:ring-dark-border"
+    >
+      {image && (
+        <div className="overflow-hidden bg-gradient-to-b from-[#1e2e47] to-[#0c0f16] p-4">
+          <Image
+            src={image.src}
+            alt={image.alt}
+            width={image.width}
+            height={image.height}
+            className="h-auto w-full rounded-md shadow-lg transition-transform duration-500 ease-out group-hover:scale-[1.04] motion-reduce:transition-none"
+          />
+        </div>
+      )}
+      <div className={featured ? 'flex flex-1 flex-col p-6 md:p-7' : 'flex flex-1 flex-col p-6'}>
+        <h3
+          className={
+            featured
+              ? 'mb-2 text-xl font-medium text-heading dark:text-dark-text'
+              : 'mb-2 text-base font-medium text-heading dark:text-dark-text'
+          }
+        >
+          {thread.title}
+        </h3>
+        <p className="mb-4 flex-1 text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
+          {thread.body}
+        </p>
+        <p className="text-sm">
+          {thread.links.map((link, index) => (
+            <Fragment key={link.href}>
+              {index > 0 && (
+                <span className="text-muted dark:text-dark-text-secondary" aria-hidden>
+                  {' · '}
+                </span>
+              )}
+              <ExternalLink href={link.href}>{link.label}</ExternalLink>
+            </Fragment>
+          ))}
+        </p>
+      </div>
     </Card>
   );
 }

--- a/src/components/interests/now-thread-card.tsx
+++ b/src/components/interests/now-thread-card.tsx
@@ -1,0 +1,27 @@
+import { Fragment } from 'react';
+import { Card } from '@/components/card';
+import { ExternalLink } from './external-link';
+import type { NowThread } from '@/lib/interests-data';
+
+export function NowThreadCard({ thread }: { thread: NowThread }) {
+  return (
+    <Card className="flex h-full flex-col">
+      <h3 className="mb-2 text-base font-medium text-heading dark:text-dark-text">{thread.title}</h3>
+      <p className="mb-4 flex-1 text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
+        {thread.body}
+      </p>
+      <p className="text-sm">
+        {thread.links.map((link, index) => (
+          <Fragment key={link.href}>
+            {index > 0 && (
+              <span className="text-muted dark:text-dark-text-secondary" aria-hidden>
+                {' · '}
+              </span>
+            )}
+            <ExternalLink href={link.href}>{link.label}</ExternalLink>
+          </Fragment>
+        ))}
+      </p>
+    </Card>
+  );
+}

--- a/src/components/interests/now-thread-card.tsx
+++ b/src/components/interests/now-thread-card.tsx
@@ -8,11 +8,9 @@ type ThreadImage = { src: string; alt: string; width: number; height: number };
 
 export function NowThreadCard({
   thread,
-  featured = false,
   coverImage,
 }: {
   thread: NowThread;
-  featured?: boolean;
   coverImage?: ThreadImage;
 }) {
   const image = thread.image ?? coverImage;
@@ -24,24 +22,18 @@ export function NowThreadCard({
       className="group flex h-full flex-col overflow-hidden ring-1 ring-border/60 dark:ring-dark-border"
     >
       {image && (
-        <div className="overflow-hidden bg-gradient-to-b from-[#1e2e47] to-[#0c0f16] p-4">
+        <div className="aspect-[16/10] overflow-hidden bg-gradient-to-b from-[#1e2e47] to-[#0c0f16] p-3">
           <Image
             src={image.src}
             alt={image.alt}
             width={image.width}
             height={image.height}
-            className="h-auto w-full rounded-md shadow-lg transition-transform duration-500 ease-out group-hover:scale-[1.04] motion-reduce:transition-none"
+            className="h-full w-full rounded-md object-cover object-top shadow-lg transition-transform duration-500 ease-out group-hover:scale-[1.04] motion-reduce:transition-none"
           />
         </div>
       )}
-      <div className={featured ? 'flex flex-1 flex-col p-6 md:p-7' : 'flex flex-1 flex-col p-6'}>
-        <h3
-          className={
-            featured
-              ? 'mb-2 text-xl font-medium text-heading dark:text-dark-text'
-              : 'mb-2 text-base font-medium text-heading dark:text-dark-text'
-          }
-        >
+      <div className="flex flex-1 flex-col p-6">
+        <h3 className="mb-2 text-base font-medium text-heading dark:text-dark-text">
           {thread.title}
         </h3>
         <p className="mb-4 flex-1 text-sm leading-relaxed text-muted dark:text-dark-text-secondary">

--- a/src/components/interests/scroll-reveal.tsx
+++ b/src/components/interests/scroll-reveal.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/cn';
+
+export function ScrollReveal({
+  children,
+  className,
+  delayMs = 0,
+  as: Tag = 'div',
+}: {
+  children: ReactNode;
+  className?: string;
+  delayMs?: number;
+  as?: 'div' | 'section';
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setShown(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setShown(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -8% 0px' }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Tag
+      ref={ref}
+      style={{ transitionDelay: shown ? `${delayMs}ms` : '0ms' }}
+      className={cn(
+        'transition-all duration-700 ease-out motion-reduce:transition-none',
+        shown ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0',
+        className
+      )}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/src/components/interests/timeline-row.tsx
+++ b/src/components/interests/timeline-row.tsx
@@ -1,0 +1,30 @@
+import { ExternalLink } from './external-link';
+import type { TimelineEntry } from '@/lib/interests-data';
+
+export function TimelineRow({ entry }: { entry: TimelineEntry }) {
+  return (
+    <div className="grid gap-1 md:grid-cols-[8rem_1fr] md:gap-6">
+      <p className="text-sm font-medium text-muted dark:text-dark-text-secondary">{entry.period}</p>
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-heading dark:text-dark-text md:text-base">
+          {entry.role}
+        </p>
+        {entry.detail && (
+          <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
+            {entry.detail}
+          </p>
+        )}
+        {entry.receipts && (
+          <ul className="space-y-1.5 text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
+            {entry.receipts.map((receipt) => (
+              <li key={receipt.href} className="flex items-start gap-2">
+                <span className="mt-2 h-1 w-1 flex-shrink-0 rounded-full bg-muted/50 dark:bg-dark-text-secondary/50" />
+                <ExternalLink href={receipt.href}>{receipt.label}</ExternalLink>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/interests/timeline-row.tsx
+++ b/src/components/interests/timeline-row.tsx
@@ -1,28 +1,76 @@
+'use client';
+
+import Image from 'next/image';
+import { useId, useState } from 'react';
 import { ExternalLink } from './external-link';
 import type { TimelineEntry } from '@/lib/interests-data';
 
 export function TimelineRow({ entry }: { entry: TimelineEntry }) {
+  const hasDetails = Boolean(entry.detail || entry.receipts || entry.image);
+  const [open, setOpen] = useState(Boolean(entry.defaultOpen));
+  const panelId = useId();
+
   return (
     <div className="grid gap-1 md:grid-cols-[8rem_1fr] md:gap-6">
-      <p className="text-sm font-medium text-muted dark:text-dark-text-secondary">{entry.period}</p>
-      <div className="space-y-2">
-        <p className="text-sm font-medium text-heading dark:text-dark-text md:text-base">
-          {entry.role}
-        </p>
-        {entry.detail && (
-          <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-            {entry.detail}
+      <p className="pt-0.5 text-sm font-medium text-muted dark:text-dark-text-secondary">
+        {entry.period}
+      </p>
+      <div>
+        {hasDetails ? (
+          <button
+            type="button"
+            aria-expanded={open}
+            aria-controls={panelId}
+            onClick={() => setOpen((v) => !v)}
+            className="group flex w-full items-start gap-2 text-left"
+          >
+            <span
+              aria-hidden
+              className={`mt-1.5 text-xs text-accent transition-transform duration-200 dark:text-dark-accent motion-reduce:transition-none ${
+                open ? 'rotate-90' : ''
+              }`}
+            >
+              &#9654;
+            </span>
+            <span className="text-sm font-medium text-heading transition-colors group-hover:text-accent dark:text-dark-text dark:group-hover:text-dark-accent md:text-base">
+              {entry.role}
+            </span>
+          </button>
+        ) : (
+          <p className="pl-5 text-sm font-medium text-heading dark:text-dark-text md:text-base">
+            {entry.role}
           </p>
         )}
-        {entry.receipts && (
-          <ul className="space-y-1.5 text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-            {entry.receipts.map((receipt) => (
-              <li key={receipt.href} className="flex items-start gap-2">
-                <span className="mt-2 h-1 w-1 flex-shrink-0 rounded-full bg-muted/50 dark:bg-dark-text-secondary/50" />
-                <ExternalLink href={receipt.href}>{receipt.label}</ExternalLink>
-              </li>
-            ))}
-          </ul>
+
+        {hasDetails && (
+          <div
+            id={panelId}
+            hidden={!open}
+            className="space-y-3 pl-5 pt-2 text-sm leading-relaxed text-muted dark:text-dark-text-secondary"
+          >
+            {entry.detail && <p>{entry.detail}</p>}
+            {entry.image && (
+              <div className="overflow-hidden rounded-lg bg-gradient-to-b from-[#1e2e47] to-[#0c0f16] p-2">
+                <Image
+                  src={entry.image.src}
+                  alt={entry.image.alt}
+                  width={entry.image.width}
+                  height={entry.image.height}
+                  className="h-auto w-full rounded"
+                />
+              </div>
+            )}
+            {entry.receipts && (
+              <ul className="space-y-1.5">
+                {entry.receipts.map((receipt) => (
+                  <li key={receipt.href} className="flex items-start gap-2">
+                    <span className="mt-2 h-1 w-1 flex-shrink-0 rounded-full bg-muted/50 dark:bg-dark-text-secondary/50" />
+                    <ExternalLink href={receipt.href}>{receipt.label}</ExternalLink>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/lib/interests-data.ts
+++ b/src/lib/interests-data.ts
@@ -120,9 +120,7 @@ export const TIMELINE: TimelineEntry[] = [
   {
     period: 'Education',
     role: 'PhD, Taras Shevchenko National University of Kyiv; MS Computer Science',
-    receipts: [
-      { label: 'The @chemistry npm scope', href: 'https://www.npmjs.com/org/chemistry' },
-    ],
+    receipts: [{ label: 'The @chemistry npm scope', href: 'https://www.npmjs.com/org/chemistry' }],
   },
 ];
 

--- a/src/lib/interests-data.ts
+++ b/src/lib/interests-data.ts
@@ -1,0 +1,95 @@
+export type NowThread = {
+  title: string;
+  body: string;
+  links: { label: string; href: string }[];
+};
+
+export type TimelineEntry = {
+  period: string;
+  role: string;
+  detail?: string;
+  receipts?: { label: string; href: string }[];
+};
+
+export type ProfileLink = {
+  label: string;
+  href: string;
+};
+
+export const NOW_THREADS: NowThread[] = [
+  {
+    title: 'AI memory',
+    body: 'Open-source work around one markdown memory every AI can read and write.',
+    links: [
+      { label: 'agentage.io', href: 'https://agentage.io' },
+      { label: 'github.com/agentage', href: 'https://github.com/agentage' },
+    ],
+  },
+  {
+    title: 'MCP ecosystem',
+    body: 'An open directory of Model Context Protocol servers, plus the tooling around it.',
+    links: [{ label: 'MCP catalog', href: 'https://catalog.agentage.io/mcp' }],
+  },
+  {
+    title: 'Writing',
+    body: 'Essays on agents, MCP, and how AI should remember.',
+    links: [{ label: 'Read the blog', href: '/blog' }],
+  },
+];
+
+export const TIMELINE: TimelineEntry[] = [
+  {
+    period: '2021 - present',
+    role: 'Senior Software Engineer, Microsoft',
+    detail: 'Frontend on products used by millions.',
+  },
+  {
+    period: '2016 - 2021',
+    role: 'Lead Software Engineer, EPAM Systems',
+    detail: 'TypeScript, React, Angular, Node, cloud.',
+  },
+  {
+    period: '2015 - 2016',
+    role: 'Software Engineer, GlobalLogic',
+  },
+  {
+    period: '2008 - 2012',
+    role: 'Post-doctoral research',
+    detail: 'University at Albany (SUNY) and CNRS / Universite de Rennes 1.',
+    receipts: [
+      {
+        label: '~480 citations, h-index 11 (Google Scholar)',
+        href: 'https://scholar.google.com/citations?user=z3jmonEAAAAJ',
+      },
+      {
+        label: 'Sole-author software paper: DiffractWD, J. Appl. Crystallogr. 44, 219-220 (2011)',
+        href: 'https://onlinelibrary.wiley.com/doi/abs/10.1107/S0021889810044614',
+      },
+    ],
+  },
+  {
+    period: 'Education',
+    role: 'PhD Inorganic Chemistry, Taras Shevchenko National University of Kyiv; MS Computer Science',
+    receipts: [
+      {
+        label: 'crystallography.io - search over 80k+ Crystallography Open Database structures',
+        href: 'https://crystallography.io',
+      },
+      { label: 'The @chemistry npm scope', href: 'https://www.npmjs.com/org/chemistry' },
+    ],
+  },
+];
+
+export const HOBBIES: string[] = [
+  'Skiing across the Czech Republic, Austria, and Italy.',
+  'Fishing, hiking, and diving whenever the season allows.',
+  'Photography and museums.',
+  'Training toward long open-water swims of 8-10 km, with an eye on the Bosphorus cross-continental swim.',
+];
+
+export const PROFILE_LINKS: ProfileLink[] = [
+  { label: 'GitHub', href: 'https://github.com/vreshch' },
+  { label: 'Google Scholar', href: 'https://scholar.google.com/citations?user=z3jmonEAAAAJ' },
+  { label: 'Medium', href: 'https://medium.com/@vreshch' },
+  { label: 'LinkedIn', href: 'https://www.linkedin.com/in/vreshch' },
+];

--- a/src/lib/interests-data.ts
+++ b/src/lib/interests-data.ts
@@ -63,17 +63,17 @@ export const NOW_THREADS: NowThread[] = [
 
 export const FOCUS_STATS: FocusStat[] = [
   {
-    label: 'citations',
-    value: 480,
-    prefix: '~',
-    href: 'https://scholar.google.com/citations?user=z3jmonEAAAAJ',
-    source: 'Google Scholar',
+    label: 'years shipping software',
+    value: 10,
+    suffix: '+',
+    href: 'https://www.linkedin.com/in/vreshch',
+    source: 'LinkedIn',
   },
   {
-    label: 'h-index',
-    value: 11,
-    href: 'https://scholar.google.com/citations?user=z3jmonEAAAAJ',
-    source: 'Google Scholar',
+    label: 'open-source repos',
+    value: 9,
+    href: 'https://github.com/agentage',
+    source: 'github.com/agentage',
   },
   {
     label: 'MCP servers indexed',
@@ -110,40 +110,30 @@ export const TIMELINE: TimelineEntry[] = [
     period: '2008 - 2012',
     role: 'Post-doctoral research',
     detail: 'University at Albany (SUNY) and CNRS / Universite de Rennes 1.',
-    image: {
-      src: '/mockups/diffractwd-com.png',
-      alt: 'DiffractWD - crystallography diffraction software',
-      width: 1360,
-      height: 967,
-    },
     receipts: [
       {
-        label: '~480 citations, h-index 11 (Google Scholar)',
+        label: 'Publications on Google Scholar',
         href: 'https://scholar.google.com/citations?user=z3jmonEAAAAJ',
-      },
-      {
-        label: 'Sole-author software paper: DiffractWD, J. Appl. Crystallogr. 44, 219-220 (2011)',
-        href: 'https://onlinelibrary.wiley.com/doi/abs/10.1107/S0021889810044614',
       },
     ],
   },
   {
     period: 'Education',
-    role: 'PhD Inorganic Chemistry, Taras Shevchenko National University of Kyiv; MS Computer Science',
-    image: {
-      src: '/mockups/crystallography-io.png',
-      alt: 'crystallography.io - search 80k+ Crystallography Open Database structures',
-      width: 1360,
-      height: 967,
-    },
+    role: 'PhD, Taras Shevchenko National University of Kyiv; MS Computer Science',
     receipts: [
-      {
-        label: 'crystallography.io - search over 80k+ Crystallography Open Database structures',
-        href: 'https://crystallography.io',
-      },
       { label: 'The @chemistry npm scope', href: 'https://www.npmjs.com/org/chemistry' },
     ],
   },
+];
+
+export const INTERESTS: string[] = [
+  'AI agents & orchestration',
+  'Model Context Protocol',
+  'AI memory & knowledge graphs',
+  'Developer experience',
+  'Open source',
+  'TypeScript & platform engineering',
+  'Infrastructure & CI/CD',
 ];
 
 export const HOBBIES: string[] = [

--- a/src/lib/interests-data.ts
+++ b/src/lib/interests-data.ts
@@ -1,6 +1,7 @@
 export type NowThread = {
   title: string;
   body: string;
+  image?: { src: string; alt: string; width: number; height: number };
   links: { label: string; href: string }[];
 };
 
@@ -9,6 +10,8 @@ export type TimelineEntry = {
   role: string;
   detail?: string;
   receipts?: { label: string; href: string }[];
+  image?: { src: string; alt: string; width: number; height: number };
+  defaultOpen?: boolean;
 };
 
 export type ProfileLink = {
@@ -16,10 +19,25 @@ export type ProfileLink = {
   href: string;
 };
 
+export type FocusStat = {
+  label: string;
+  value: number;
+  prefix?: string;
+  suffix?: string;
+  href: string;
+  source: string;
+};
+
 export const NOW_THREADS: NowThread[] = [
   {
     title: 'AI memory',
-    body: 'Open-source work around one markdown memory every AI can read and write.',
+    body: 'Open-source work around one markdown memory every AI can read and write - owned by you, mirrored as plain files.',
+    image: {
+      src: '/mockups/agentage-io.png',
+      alt: 'agentage.io - one memory every AI can read and write',
+      width: 1360,
+      height: 967,
+    },
     links: [
       { label: 'agentage.io', href: 'https://agentage.io' },
       { label: 'github.com/agentage', href: 'https://github.com/agentage' },
@@ -27,13 +45,48 @@ export const NOW_THREADS: NowThread[] = [
   },
   {
     title: 'MCP ecosystem',
-    body: 'An open directory of Model Context Protocol servers, plus the tooling around it.',
+    body: 'An open directory of Model Context Protocol servers - the connective tissue between AI and the tools it uses.',
+    image: {
+      src: '/mockups/mcp-directory.png',
+      alt: 'The MCP directory - an open catalog of Model Context Protocol servers',
+      width: 1360,
+      height: 967,
+    },
     links: [{ label: 'MCP catalog', href: 'https://catalog.agentage.io/mcp' }],
   },
   {
     title: 'Writing',
-    body: 'Essays on agents, MCP, and how AI should remember.',
+    body: 'Essays on agents, MCP, and how AI should remember - thinking out loud as I build.',
     links: [{ label: 'Read the blog', href: '/blog' }],
+  },
+];
+
+export const FOCUS_STATS: FocusStat[] = [
+  {
+    label: 'citations',
+    value: 480,
+    prefix: '~',
+    href: 'https://scholar.google.com/citations?user=z3jmonEAAAAJ',
+    source: 'Google Scholar',
+  },
+  {
+    label: 'h-index',
+    value: 11,
+    href: 'https://scholar.google.com/citations?user=z3jmonEAAAAJ',
+    source: 'Google Scholar',
+  },
+  {
+    label: 'MCP servers indexed',
+    value: 15,
+    suffix: 'k+',
+    href: 'https://catalog.agentage.io/mcp',
+    source: 'the catalog',
+  },
+  {
+    label: 'essays in 2026',
+    value: 6,
+    href: '/blog',
+    source: 'the blog',
   },
 ];
 
@@ -42,6 +95,7 @@ export const TIMELINE: TimelineEntry[] = [
     period: '2021 - present',
     role: 'Senior Software Engineer, Microsoft',
     detail: 'Frontend on products used by millions.',
+    defaultOpen: true,
   },
   {
     period: '2016 - 2021',
@@ -56,6 +110,12 @@ export const TIMELINE: TimelineEntry[] = [
     period: '2008 - 2012',
     role: 'Post-doctoral research',
     detail: 'University at Albany (SUNY) and CNRS / Universite de Rennes 1.',
+    image: {
+      src: '/mockups/diffractwd-com.png',
+      alt: 'DiffractWD - crystallography diffraction software',
+      width: 1360,
+      height: 967,
+    },
     receipts: [
       {
         label: '~480 citations, h-index 11 (Google Scholar)',
@@ -70,6 +130,12 @@ export const TIMELINE: TimelineEntry[] = [
   {
     period: 'Education',
     role: 'PhD Inorganic Chemistry, Taras Shevchenko National University of Kyiv; MS Computer Science',
+    image: {
+      src: '/mockups/crystallography-io.png',
+      alt: 'crystallography.io - search 80k+ Crystallography Open Database structures',
+      width: 1360,
+      height: 967,
+    },
     receipts: [
       {
         label: 'crystallography.io - search over 80k+ Crystallography Open Database structures',


### PR DESCRIPTION
## What
Rebuilds /interests as a visual, AI-first page for coworkers, recruiters, and scouts:

- Short first-person bio + avatar (Microsoft named once), interest chip list (AI-forward)
- "Current focus / AI" media cards: AI memory, MCP ecosystem, Writing (browser mockups + latest blog cover)
- Animated count-up stat strip: 10+ years shipping, 9 OSS repos, 15k+ MCP servers indexed, 6 essays in 2026 - each linked to its proof
- Expandable, keyboard-accessible Track record timeline (PhD kept as fact, chemistry de-emphasized)
- Beyond the keyboard (hobbies) + Find me link row
- Homepage: subtle "More about me" link on the Career card
- Old Areas of Interest / Tech Stack grid / What I'm Building removed; /cv redirect intact

## Verify
- npm run verify green (23/23 tests)
- Reviewed live in Chrome: dark + light themes, timeline expand states, stat counters, reduced-motion respected
