### PR TITLE
feat(contacts): working Resend-backed contact form

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,16 @@ jobs:
           scp -i ~/.ssh/deploy_key scripts/deploy.sh root@${{ secrets.SERVER_HOST }}:/opt/vreshch-com/
           ssh -i ~/.ssh/deploy_key root@${{ secrets.SERVER_HOST }} "chmod +x /opt/vreshch-com/deploy.sh"
 
+      - name: 🔑 Write runtime env on server
+        run: |
+          echo "🔑 Writing /opt/vreshch-com/.env (runtime secrets)..."
+          ssh -i ~/.ssh/deploy_key root@${{ secrets.SERVER_HOST }} "install -m 600 /dev/stdin /opt/vreshch-com/.env" <<'ENV_EOF'
+          RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
+          CONTACT_TO_EMAIL=vreshch@gmail.com
+          CONTACT_FROM_EMAIL=Volodymyr Vreshch <no-reply@mail.agentage.io>
+          ENV_EOF
+          echo "✅ Runtime env written"
+
       - name: 🚀 Deploy application
         id: deploy
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   web:
     image: ghcr.io/vreshch/vreshch.com:latest
     restart: unless-stopped
+    env_file:
+      - .env
     networks:
       - traefik-public
     deploy:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "remark-gfm": "^4.0.1",
         "sharp": "^0.35.3",
         "shiki": "^4.3.1",
-        "tailwind-merge": "^3.6.0"
+        "tailwind-merge": "^3.6.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
@@ -11904,6 +11905,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "remark-gfm": "^4.0.1",
     "sharp": "^0.35.3",
     "shiki": "^4.3.1",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+export const runtime = 'nodejs';
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+
+const contactSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  email: z.string().trim().email().max(200),
+  message: z.string().trim().min(1).max(5000),
+  website: z.string().optional(),
+});
+
+const hits = new Map<string, number[]>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  for (const [key, times] of hits) {
+    const fresh = times.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+    if (fresh.length === 0) hits.delete(key);
+    else hits.set(key, fresh);
+  }
+  const recent = (hits.get(ip) ?? []).filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+  if (recent.length >= RATE_LIMIT_MAX) return true;
+  recent.push(now);
+  hits.set(ip, recent);
+  return false;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildHtml(name: string, email: string, message: string): string {
+  return `<div style="font-family:sans-serif;font-size:15px;line-height:1.6;color:#374a60;">
+  <p><strong>Name:</strong> ${escapeHtml(name)}</p>
+  <p><strong>Email:</strong> ${escapeHtml(email)}</p>
+  <p><strong>Message:</strong></p>
+  <p style="white-space:pre-wrap;">${escapeHtml(message)}</p>
+</div>`;
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid request.' }, { status: 400 });
+  }
+
+  const parsed = contactSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: 'Please check your name, email, and message.' },
+      { status: 400 }
+    );
+  }
+
+  const { name, email, message, website } = parsed.data;
+
+  // Honeypot: silently drop bots that fill the hidden field.
+  if (website && website.trim() !== '') {
+    return NextResponse.json({ success: true });
+  }
+
+  if (isRateLimited(ip)) {
+    return NextResponse.json(
+      { success: false, error: 'Too many requests, please try again later.' },
+      { status: 429 }
+    );
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.error('[contact] RESEND_API_KEY is not set');
+    return NextResponse.json(
+      { success: false, error: 'Email is not configured.' },
+      { status: 500 }
+    );
+  }
+
+  const to = process.env.CONTACT_TO_EMAIL || 'vreshch@gmail.com';
+  const from = process.env.CONTACT_FROM_EMAIL || 'Volodymyr Vreshch <no-reply@mail.agentage.io>';
+
+  try {
+    const res = await fetch(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from,
+        to: [to],
+        reply_to: email,
+        subject: `New message from ${name} via vreshch.com`,
+        html: buildHtml(name, email, message),
+      }),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      console.error(`[contact] resend send failed (${res.status}): ${detail}`);
+      return NextResponse.json(
+        { success: false, error: 'Could not send your message. Please email me directly.' },
+        { status: 502 }
+      );
+    }
+  } catch (err) {
+    console.error('[contact] resend request threw', err);
+    return NextResponse.json(
+      { success: false, error: 'Could not send your message. Please email me directly.' },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -3,13 +3,14 @@ import Image from 'next/image';
 import { Card } from '@/components/card';
 import { PageHeader } from '@/components/page-header';
 import { CopyEmailButton } from '@/components/copy-email-button';
+import { ContactForm } from '@/components/contact-form';
 
 const EMAIL = 'vreshch@gmail.com';
 
 export const metadata: Metadata = {
   title: 'Contacts',
   description:
-    'Get in touch with Volodymyr Vreshch by email or via LinkedIn, GitHub, Facebook, and Instagram.',
+    'Get in touch with Volodymyr Vreshch by email, send a message, or connect via LinkedIn, GitHub, Facebook, and Instagram.',
   alternates: { canonical: '/contacts' },
   openGraph: {
     title: 'Contacts',
@@ -146,6 +147,15 @@ export default function ContactsPage() {
             </div>
           </div>
         </Card>
+
+        <section className="mt-12">
+          <h2 className="mb-6 text-lg font-medium text-heading dark:text-dark-text">
+            Send a message
+          </h2>
+          <Card>
+            <ContactForm />
+          </Card>
+        </section>
       </div>
     </div>
   );

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+
+const inputStyles =
+  'w-full rounded-xl border-0 bg-surface px-4 py-3 text-sm text-heading placeholder:text-muted/60 focus:outline-none focus:ring-2 focus:ring-accent/40 dark:bg-dark-surface-alt dark:text-dark-text dark:placeholder:text-dark-text-secondary/40 dark:focus:ring-dark-accent/40';
+
+const labelStyles =
+  'mb-1.5 block text-xs font-medium uppercase tracking-widest text-muted dark:text-dark-text-secondary';
+
+type Status = 'idle' | 'sending' | 'sent' | 'error';
+
+export function ContactForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [website, setWebsite] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('sending');
+    setError('');
+
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, message, website }),
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (res.ok && data.success) {
+        setStatus('sent');
+        setName('');
+        setEmail('');
+        setMessage('');
+        return;
+      }
+      setError(data.error || 'Something went wrong. Please try again.');
+      setStatus('error');
+    } catch {
+      setError('Something went wrong. Please try again.');
+      setStatus('error');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="name" className={labelStyles}>
+            Name
+          </label>
+          <input
+            id="name"
+            type="text"
+            placeholder="Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            maxLength={100}
+            className={inputStyles}
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className={labelStyles}>
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            maxLength={200}
+            className={inputStyles}
+          />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="message" className={labelStyles}>
+          Message
+        </label>
+        <textarea
+          id="message"
+          rows={5}
+          placeholder="What would you like to discuss?"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          maxLength={5000}
+          className={`${inputStyles} resize-none`}
+        />
+      </div>
+
+      <div className="absolute -left-[9999px]" aria-hidden="true">
+        <label htmlFor="website">Leave this field empty</label>
+        <input
+          id="website"
+          type="text"
+          name="website"
+          tabIndex={-1}
+          autoComplete="off"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 pt-2">
+        <button
+          type="submit"
+          disabled={status === 'sending'}
+          className="inline-block rounded-full bg-accent px-8 py-3.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60 dark:bg-dark-accent dark:text-dark-bg dark:hover:bg-dark-accent-hover"
+        >
+          {status === 'sending' ? 'Sending...' : 'Send Message'}
+        </button>
+        {status === 'sent' && (
+          <p className="text-sm font-medium text-accent dark:text-dark-accent">
+            Thanks - your message is on its way.
+          </p>
+        )}
+        {status === 'error' && (
+          <p className="text-sm font-medium text-red-600 dark:text-red-400">{error}</p>
+        )}
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## What
Adds a working contact form on /contacts that emails vreshch@gmail.com via Resend (reuses the agentage Resend account; sends from the verified no-reply@mail.agentage.io, visitor address as reply-to).

- `POST /api/contact` route: Zod validation, honeypot (silent bot drop), per-IP rate limit (5/10min), HTML-escaped body, plain fetch to Resend (no SDK)
- Client `ContactForm` with idle/sending/sent/error states; kept the existing Email me / Copy address CTA above it
- Runtime secret plumbing: `env_file: .env` in compose; deploy step writes /opt/vreshch-com/.env from the new `RESEND_API_KEY` repo secret; `.env` gitignored
- Adds `zod` (house-standard validation lib; no `resend` SDK added)

## Verify
- npm run verify + prettier green
- Local smoke test with the real key: honeypot -> silent 200, invalid -> 400, real send -> 200 and the email arrived in vreshch@gmail.com inbox (not spam) from no-reply@mail.agentage.io
