### PR TITLE
feat: GA conversion event tracking

### DIFF
--- a/src/app/interests/page.tsx
+++ b/src/app/interests/page.tsx
@@ -104,7 +104,7 @@ export default async function InterestsPage() {
           <h2 className="mb-6 text-2xl font-medium text-heading dark:text-dark-text">Find me</h2>
           <div className="flex flex-wrap gap-x-6 gap-y-3">
             {PROFILE_LINKS.map((link) => (
-              <ExternalLink key={link.href} href={link.href}>
+              <ExternalLink key={link.href} href={link.href} label={link.label}>
                 {link.label}
               </ExternalLink>
             ))}

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { trackEvent } from '@/lib/analytics';
 
 const inputStyles =
   'w-full rounded-xl border-0 bg-surface px-4 py-3 text-sm text-heading placeholder:text-muted/60 focus:outline-none focus:ring-2 focus:ring-accent/40 dark:bg-dark-surface-alt dark:text-dark-text dark:placeholder:text-dark-text-secondary/40 dark:focus:ring-dark-accent/40';
@@ -32,15 +33,18 @@ export function ContactForm() {
       const data = await res.json().catch(() => ({}));
 
       if (res.ok && data.success) {
+        trackEvent('contact_submit', { method: 'form' });
         setStatus('sent');
         setName('');
         setEmail('');
         setMessage('');
         return;
       }
+      trackEvent('contact_submit_error', { method: 'form' });
       setError(data.error || 'Something went wrong. Please try again.');
       setStatus('error');
     } catch {
+      trackEvent('contact_submit_error', { method: 'form' });
       setError('Something went wrong. Please try again.');
       setStatus('error');
     }

--- a/src/components/featured-project-card.tsx
+++ b/src/components/featured-project-card.tsx
@@ -1,10 +1,18 @@
+'use client';
+
 import Image from 'next/image';
 import { Card } from '@/components/card';
+import { trackEvent } from '@/lib/analytics';
 import type { FeaturedProject } from '@/lib/featured-projects';
 
 export function FeaturedProjectCard({ project }: { project: FeaturedProject }) {
   return (
-    <a href={project.url} target="_blank" rel="noreferrer">
+    <a
+      href={project.url}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() => trackEvent('outbound_click', { url: project.url, label: project.name })}
+    >
       <Card hover="lift" padding="none" className="flex h-full flex-col overflow-hidden">
         {project.image ? (
           <div className="bg-gradient-to-b from-[#1e2e47] to-[#0c0f16] p-4">

--- a/src/components/interests/external-link.tsx
+++ b/src/components/interests/external-link.tsx
@@ -1,25 +1,39 @@
-import Link from 'next/link';
+'use client';
 
-export function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
+import Link from 'next/link';
+import { trackEvent } from '@/lib/analytics';
+
+const linkStyles =
+  'font-medium text-accent transition-colors hover:text-accent-hover dark:text-dark-accent dark:hover:text-dark-accent-hover';
+
+export function ExternalLink({
+  href,
+  children,
+  label,
+}: {
+  href: string;
+  children: React.ReactNode;
+  label?: string;
+}) {
   const isInternal = href.startsWith('/');
 
   if (isInternal) {
     return (
-      <Link
-        href={href}
-        className="font-medium text-accent transition-colors hover:text-accent-hover dark:text-dark-accent dark:hover:text-dark-accent-hover"
-      >
+      <Link href={href} className={linkStyles}>
         {children}
       </Link>
     );
   }
+
+  const eventLabel = label ?? (typeof children === 'string' ? children : href);
 
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener"
-      className="font-medium text-accent transition-colors hover:text-accent-hover dark:text-dark-accent dark:hover:text-dark-accent-hover"
+      className={linkStyles}
+      onClick={() => trackEvent('outbound_click', { url: href, label: eventLabel })}
     >
       {children}
     </a>

--- a/src/components/interests/focus-stats.tsx
+++ b/src/components/interests/focus-stats.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { trackEvent } from '@/lib/analytics';
 import type { FocusStat } from '@/lib/interests-data';
 
 function StatCell({ stat }: { stat: FocusStat }) {
@@ -8,6 +11,11 @@ function StatCell({ stat }: { stat: FocusStat }) {
     <Link
       href={stat.href}
       {...linkProps}
+      onClick={
+        external
+          ? () => trackEvent('outbound_click', { url: stat.href, label: stat.source })
+          : undefined
+      }
       className="group flex flex-col gap-1 rounded-xl px-1 py-2 transition-colors hover:bg-surface-alt dark:hover:bg-dark-surface-alt"
     >
       <span className="text-3xl font-semibold tabular-nums tracking-tight text-heading dark:text-dark-text md:text-4xl">

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,14 @@
+export type GtagParams = Record<string, string | number | boolean>;
+
+type GtagFn = (command: 'event', name: string, params?: GtagParams) => void;
+
+declare global {
+  interface Window {
+    gtag?: GtagFn;
+  }
+}
+
+export function trackEvent(name: string, params?: GtagParams): void {
+  if (typeof window === 'undefined') return;
+  window.gtag?.('event', name, params);
+}


### PR DESCRIPTION
Adds GA4 conversion events (analytics.ts helper, gtag typed on Window): `contact_submit` / `contact_submit_error` on the contact form, and `outbound_click` (url+label) on the homepage project cards and /interests external links. Page-view-only tracking previously meant no visibility into whether the site converts. Events fire in prod only (matches existing GA gate).
