### PR TITLE
feat(blog): tag pages + prev/next navigation

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,7 +3,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { BlogMdx } from '@/components/blog-mdx';
-import { formatPostDate, getAllPostSlugs, getPost } from '@/lib/blog';
+import { TagChips } from '@/components/tag-chip';
+import { formatPostDate, getAdjacentPosts, getAllPostSlugs, getPost } from '@/lib/blog';
 
 type Params = { slug: string };
 
@@ -61,6 +62,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
   const post = await getPost(slug);
   if (!post) notFound();
 
+  const { prev, next } = await getAdjacentPosts(slug);
   const sourceUrl = `${REPO_URL}/blob/${REPO_BRANCH}/src/content/blog/${post.slug}/article.md`;
   const postUrl = `${SITE}/blog/${post.slug}`;
 
@@ -125,18 +127,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
             {post.subtitle}
           </p>
         )}
-        {post.tags && post.tags.length > 0 && (
-          <ul className="flex flex-wrap gap-2">
-            {post.tags.map((tag) => (
-              <li
-                key={tag}
-                className="rounded-full bg-surface px-3 py-1 text-xs font-medium text-muted dark:bg-dark-surface dark:text-dark-text-secondary"
-              >
-                {tag}
-              </li>
-            ))}
-          </ul>
-        )}
+        {post.tags && post.tags.length > 0 && <TagChips tags={post.tags} />}
         {post.mediumUrl && (
           <p className="mt-5 text-sm">
             <a
@@ -187,6 +178,39 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
       <div className="prose-blog">
         <BlogMdx source={post.content} />
       </div>
+      {(prev || next) && (
+        <nav
+          aria-label="More posts"
+          className="mt-16 grid gap-4 border-t border-border/30 pt-8 sm:grid-cols-2 dark:border-dark-border"
+        >
+          {prev ? (
+            <Link
+              href={`/blog/${prev.slug}`}
+              className="group flex flex-col gap-1 rounded-lg border border-border/60 p-4 transition-colors hover:border-accent/60 dark:border-dark-border dark:hover:border-dark-accent/60"
+            >
+              <span className="text-xs font-medium uppercase tracking-wide text-muted dark:text-dark-text-secondary">
+                ← Previous
+              </span>
+              <span className="font-medium text-heading dark:text-dark-text">{prev.title}</span>
+            </Link>
+          ) : (
+            <span aria-hidden="true" className="hidden sm:block" />
+          )}
+          {next ? (
+            <Link
+              href={`/blog/${next.slug}`}
+              className="group flex flex-col gap-1 rounded-lg border border-border/60 p-4 text-right transition-colors hover:border-accent/60 dark:border-dark-border dark:hover:border-dark-accent/60"
+            >
+              <span className="text-xs font-medium uppercase tracking-wide text-muted dark:text-dark-text-secondary">
+                Next →
+              </span>
+              <span className="font-medium text-heading dark:text-dark-text">{next.title}</span>
+            </Link>
+          ) : (
+            <span aria-hidden="true" className="hidden sm:block" />
+          )}
+        </nav>
+      )}
       <footer className="mt-16 flex flex-wrap items-center justify-between gap-4 border-t border-border/30 pt-8 text-sm text-muted dark:border-dark-border dark:text-dark-text-secondary">
         <Link
           href="/blog"

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from 'next';
-import Image from 'next/image';
-import Link from 'next/link';
 import { PageHeader } from '@/components/page-header';
-import { Card } from '@/components/card';
-import { getAllPosts, formatPostDate, type BlogPostMeta } from '@/lib/blog';
+import { PostCard } from '@/components/post-card';
+import { getAllPosts } from '@/lib/blog';
 
 export const metadata: Metadata = {
   title: 'Blog',
@@ -16,47 +14,6 @@ export const metadata: Metadata = {
     siteName: 'Volodymyr Vreshch',
   },
 };
-
-function PostCard({ post }: { post: BlogPostMeta }) {
-  return (
-    <Link href={`/blog/${post.slug}`} className="block">
-      <Card hover="lift" padding="none" className="overflow-hidden">
-        <div className="grid items-center md:grid-cols-2">
-          <div className="p-4 md:p-6">
-            <div className="relative aspect-[16/9] w-full overflow-hidden rounded-lg border border-border/60 bg-surface-alt dark:border-dark-border dark:bg-dark-surface-alt">
-              {post.coverUrl ? (
-                <Image
-                  src={post.thumbnailUrl ?? post.coverUrl}
-                  alt={post.title}
-                  fill
-                  sizes="(min-width: 768px) 50vw, 100vw"
-                  className="object-cover object-center"
-                />
-              ) : (
-                <div className="h-full w-full bg-gradient-to-br from-surface to-surface-alt dark:from-dark-surface dark:to-dark-surface-alt" />
-              )}
-            </div>
-          </div>
-          <div className="flex flex-col justify-center p-6 md:p-8">
-            <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted dark:text-dark-text-secondary">
-              <time dateTime={post.date}>{formatPostDate(post.date)}</time>
-              <span aria-hidden="true">·</span>
-              <span>{post.readingTime}</span>
-            </div>
-            <h2 className="mb-2 text-2xl font-medium leading-snug text-heading dark:text-dark-text md:text-3xl">
-              {post.title}
-            </h2>
-            {post.subtitle && (
-              <p className="line-clamp-2 text-sm text-muted dark:text-dark-text-secondary md:text-base">
-                {post.subtitle}
-              </p>
-            )}
-          </div>
-        </div>
-      </Card>
-    </Link>
-  );
-}
 
 export default async function BlogIndexPage() {
   const posts = await getAllPosts();

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { PageHeader } from '@/components/page-header';
+import { PostCard } from '@/components/post-card';
+import { getAllTags, getPostsByTag } from '@/lib/blog';
+
+type Params = { tag: string };
+
+export async function generateStaticParams(): Promise<Params[]> {
+  const tags = await getAllTags();
+  return tags.map(({ tag }) => ({ tag }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { tag } = await params;
+  const title = `Posts tagged ${tag}`;
+  return {
+    title,
+    description: `Blog posts tagged ${tag}.`,
+    alternates: { canonical: `/blog/tag/${tag}` },
+    openGraph: {
+      title,
+      description: `Blog posts tagged ${tag}.`,
+      url: `/blog/tag/${tag}`,
+      siteName: 'Volodymyr Vreshch',
+    },
+  };
+}
+
+export default async function BlogTagPage({ params }: { params: Promise<Params> }) {
+  const { tag } = await params;
+  const posts = await getPostsByTag(tag);
+  if (posts.length === 0) notFound();
+
+  return (
+    <div>
+      <PageHeader
+        title={`Posts tagged “${tag}”`}
+        description={`${posts.length} post${posts.length === 1 ? '' : 's'}.`}
+      />
+
+      <div className="mx-auto max-w-5xl px-6 pb-16 md:pb-24">
+        <Link
+          href="/blog"
+          className="mb-8 inline-flex items-center gap-2 text-sm text-muted transition-colors hover:text-heading dark:text-dark-text-secondary dark:hover:text-dark-text"
+        >
+          ← All posts
+        </Link>
+        <ul className="flex flex-col gap-8">
+          {posts.map((post) => (
+            <li key={post.slug}>
+              <PostCard post={post} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,15 +1,23 @@
 import type { MetadataRoute } from 'next';
-import { getAllPosts } from '@/lib/blog';
+import { getAllPosts, getAllTags } from '@/lib/blog';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://vreshch.com';
   const posts = await getAllPosts();
+  const tags = await getAllTags();
 
   const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${baseUrl}/blog/${post.slug}`,
     lastModified: new Date(post.date),
     changeFrequency: 'monthly',
     priority: 0.8,
+  }));
+
+  const tagEntries: MetadataRoute.Sitemap = tags.map(({ tag }) => ({
+    url: `${baseUrl}/blog/tag/${tag}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly',
+    priority: 0.5,
   }));
 
   return [
@@ -33,6 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     ...postEntries,
+    ...tagEntries,
     {
       url: `${baseUrl}/contacts`,
       lastModified: new Date(),

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { Card } from '@/components/card';
+import { TagChips } from '@/components/tag-chip';
+import { formatPostDate, type BlogPostMeta } from '@/lib/blog';
+
+export function PostCard({ post }: { post: BlogPostMeta }) {
+  return (
+    <Card hover="lift" padding="none" className="overflow-hidden">
+      <div className="grid items-center md:grid-cols-2">
+        <div className="p-4 md:p-6">
+          <Link
+            href={`/blog/${post.slug}`}
+            aria-label={post.title}
+            className="relative block aspect-[16/9] w-full overflow-hidden rounded-lg border border-border/60 bg-surface-alt dark:border-dark-border dark:bg-dark-surface-alt"
+          >
+            {post.coverUrl ? (
+              <Image
+                src={post.thumbnailUrl ?? post.coverUrl}
+                alt={post.title}
+                fill
+                sizes="(min-width: 768px) 50vw, 100vw"
+                className="object-cover object-center"
+              />
+            ) : (
+              <div className="h-full w-full bg-gradient-to-br from-surface to-surface-alt dark:from-dark-surface dark:to-dark-surface-alt" />
+            )}
+          </Link>
+        </div>
+        <div className="flex flex-col justify-center p-6 md:p-8">
+          <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted dark:text-dark-text-secondary">
+            <time dateTime={post.date}>{formatPostDate(post.date)}</time>
+            <span aria-hidden="true">·</span>
+            <span>{post.readingTime}</span>
+          </div>
+          <h2 className="mb-2 text-2xl font-medium leading-snug text-heading dark:text-dark-text md:text-3xl">
+            <Link href={`/blog/${post.slug}`} className="transition-colors hover:text-accent">
+              {post.title}
+            </Link>
+          </h2>
+          {post.subtitle && (
+            <p className="line-clamp-2 text-sm text-muted dark:text-dark-text-secondary md:text-base">
+              {post.subtitle}
+            </p>
+          )}
+          {post.tags && post.tags.length > 0 && (
+            <div className="mt-4">
+              <TagChips tags={post.tags} />
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/tag-chip.tsx
+++ b/src/components/tag-chip.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+export function TagChip({ tag }: { tag: string }) {
+  return (
+    <Link
+      href={`/blog/tag/${tag}`}
+      className="rounded-full border border-border/70 bg-surface-alt px-3 py-1 text-xs font-medium text-muted transition-colors hover:text-heading dark:border-dark-border dark:bg-dark-surface-alt dark:text-dark-text-secondary dark:hover:text-dark-text"
+    >
+      {tag}
+    </Link>
+  );
+}
+
+export function TagChips({ tags }: { tags: string[] }) {
+  if (tags.length === 0) return null;
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {tags.map((tag) => (
+        <li key={tag}>
+          <TagChip tag={tag} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -144,6 +144,39 @@ export async function getPost(slug: string): Promise<BlogPost | null> {
   }
 }
 
+export type TagCount = { tag: string; count: number };
+
+export async function getAllTags(): Promise<TagCount[]> {
+  const posts = await getAllPosts();
+  const counts = new Map<string, number>();
+  for (const post of posts) {
+    for (const tag of post.tags ?? []) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => a.tag.localeCompare(b.tag));
+}
+
+export async function getPostsByTag(tag: string): Promise<BlogPostMeta[]> {
+  const posts = await getAllPosts();
+  return posts.filter((post) => (post.tags ?? []).includes(tag));
+}
+
+// Posts are newest-first; prev = newer post, next = older post.
+export async function getAdjacentPosts(
+  slug: string
+): Promise<{ prev: BlogPostMeta | null; next: BlogPostMeta | null }> {
+  const posts = await getAllPosts();
+  const index = posts.findIndex((post) => post.slug === slug);
+  if (index === -1) return { prev: null, next: null };
+  return {
+    prev: index > 0 ? posts[index - 1] : null,
+    next: index < posts.length - 1 ? posts[index + 1] : null,
+  };
+}
+
 export function formatPostDate(iso: string): string {
   const date = new Date(iso);
   return date.toLocaleDateString('en-US', {


### PR DESCRIPTION
Adds topic navigation to the blog: tag chips on post cards + post headers, `/blog/tag/<tag>` listing pages (statically generated, in sitemap), and prev/next post navigation. New blog.ts helpers: getAllTags, getPostsByTag, getAdjacentPosts. Tags already existed in post frontmatter; this surfaces them.
