### PR TITLE
feat(blog): RSS 2.0 feed + autodiscovery

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
   authors: [{ name: 'Volodymyr Vreshch' }],
   icons: { icon: '/icon.svg' },
   metadataBase: new URL('https://vreshch.com'),
+  alternates: {
+    types: { 'application/rss+xml': '/rss.xml' },
+  },
   openGraph: {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,61 @@
+import { getAllPosts } from '@/lib/blog';
+
+export const dynamic = 'force-static';
+
+const SITE_URL = 'https://vreshch.com';
+const FEED_TITLE = 'Volodymyr Vreshch - Blog';
+const FEED_DESCRIPTION =
+  'Notes on agents, MCP, and the craft of shipping - with an occasional detour.';
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+// Unquoted YAML dates arrive as Date objects, so normalize via the constructor.
+function toRfc822(value: string): string {
+  return new Date(value).toUTCString();
+}
+
+export async function GET(): Promise<Response> {
+  const posts = await getAllPosts();
+
+  const items = posts
+    .map((post) => {
+      const link = `${SITE_URL}/blog/${post.slug}`;
+      const description = post.description ?? post.subtitle ?? '';
+      return [
+        '    <item>',
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${escapeXml(link)}</link>`,
+        `      <guid isPermaLink="true">${escapeXml(link)}</guid>`,
+        `      <pubDate>${toRfc822(post.date)}</pubDate>`,
+        `      <description>${escapeXml(description)}</description>`,
+        '    </item>',
+      ].join('\n');
+    })
+    .join('\n');
+
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    `    <title>${escapeXml(FEED_TITLE)}</title>`,
+    `    <link>${SITE_URL}/blog</link>`,
+    `    <description>${escapeXml(FEED_DESCRIPTION)}</description>`,
+    '    <language>en</language>',
+    `    <atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml" />`,
+    items,
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n');
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  });
+}


### PR DESCRIPTION
Adds an RSS 2.0 feed at `/rss.xml` (built by hand from getAllPosts, RFC-822 dates, XML-escaped, force-static) plus `<link rel=alternate application/rss+xml>` autodiscovery in the layout. The writing-first site had no feed; peers subscribe via RSS.
