### PR TITLE
chore: bump typescript to ^6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "postcss": "^8.5.24",
         "prettier": "^3.9.6",
         "tailwindcss": "^4.1.8",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -1681,9 +1681,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1699,9 +1696,6 @@
       "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1719,9 +1713,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1737,9 +1728,6 @@
       "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2413,9 +2401,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2433,9 +2418,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2453,9 +2435,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2473,9 +2452,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11194,9 +11170,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "postcss": "^8.5.24",
     "prettier": "^3.9.6",
     "tailwindcss": "^4.1.8",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   }
 }

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1,0 +1,2 @@
+// TS6 (TS2882) requires declarations for side-effect CSS imports
+declare module '*.css';


### PR DESCRIPTION
## What
- Bump `typescript` `^5.8.3` → `^6.0.3` (resolves 6.0.3)
- Add `src/css.d.ts` with `declare module '*.css'` — TS6 now emits TS2882 for side-effect imports of CSS files (globals.css, crystalview.css, molpad.css)

No @typescript-eslint change needed: already `^8.x`, resolves to 8.65.0 (peer-compatible with TS 6.0, cap `<6.1.0`).

## Verify
`npm run verify` green: type-check + lint + build (Next 15.5.22) + 23/23 vitest tests. Prettier clean.