### PR TITLE
chore: bump @agentage/observability to 0.3.0 (semconv span names)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "@agentage/observability": "^0.2.1",
+        "@agentage/observability": "^0.3.0",
         "@chemistry/crystalview": "^3.0.0",
         "@chemistry/molpad": "^3.1.0",
         "@vercel/otel": "^2.1.3",
@@ -71,9 +71,9 @@
       "license": "MIT"
     },
     "node_modules/@agentage/observability": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@agentage/observability/-/observability-0.2.1.tgz",
-      "integrity": "sha512-shGQRYRNHJuCFzJRGF3P+wYVXI40CMto7ob5rbzG70gSuEL32UwhxTCS9SeCNrNOi2DTSW1OFqvQ9u/ZRHCMNQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@agentage/observability/-/observability-0.3.0.tgz",
+      "integrity": "sha512-/+Oxv6XDfjHTHWMA9MpLJSzhq2qbJZ4C42/owS6Ac/XtSG6Hk5PDKODf5Vdc7OnDkMZtbOLNbHfhQQ7F0ZyMFA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -81,6 +81,7 @@
         "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/sdk-node": "^0.221.0",
+        "@opentelemetry/sdk-trace-base": "^2.2.0",
         "@opentelemetry/semantic-conventions": "^1.43.0",
         "pino": "^10.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:e2e:ui": "npx playwright test --ui"
   },
   "dependencies": {
-    "@agentage/observability": "^0.2.1",
+    "@agentage/observability": "^0.3.0",
     "@chemistry/crystalview": "^3.0.0",
     "@chemistry/molpad": "^3.1.0",
     "@vercel/otel": "^2.1.3",


### PR DESCRIPTION
Bumps @agentage/observability from ^0.2.1 to ^0.3.0. 0.3.0 normalizes fetch client span names inside the kit's /next entry to semconv `{method} {route}` (query strings and id-shaped path params stripped). Dependency bump only, no code changes.