### PR TITLE
chore: bump @agentage/observability to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "@agentage/observability": "^0.3.0",
+        "@agentage/observability": "^0.4.0",
         "@chemistry/crystalview": "^3.0.0",
         "@chemistry/molpad": "^3.1.0",
         "@vercel/otel": "^2.1.3",
@@ -71,9 +71,9 @@
       "license": "MIT"
     },
     "node_modules/@agentage/observability": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@agentage/observability/-/observability-0.3.0.tgz",
-      "integrity": "sha512-/+Oxv6XDfjHTHWMA9MpLJSzhq2qbJZ4C42/owS6Ac/XtSG6Hk5PDKODf5Vdc7OnDkMZtbOLNbHfhQQ7F0ZyMFA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@agentage/observability/-/observability-0.4.0.tgz",
+      "integrity": "sha512-LCmiIQv4eUi+ZXHoyHyOHTr8vn9Qoy7K4luGRn1llHdZtzMrNEXAvz0JoOjxcHtrlwlMbfJBwmv3iX57BDX9hg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:e2e:ui": "npx playwright test --ui"
   },
   "dependencies": {
-    "@agentage/observability": "^0.3.0",
+    "@agentage/observability": "^0.4.0",
     "@chemistry/crystalview": "^3.0.0",
     "@chemistry/molpad": "^3.1.0",
     "@vercel/otel": "^2.1.3",


### PR DESCRIPTION
Dependency-only bump of @agentage/observability from ^0.3.0 to ^0.4.0, which adds a Next.js noise sampler that drops health-probe traces and internal machinery spans from exported telemetry; no application code changes in this repo, and local verify (type-check, lint, build, test) passes green.