### PR TITLE
chore: kit 0.6.2 - RSC fold lands at span end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,9 +71,9 @@
       "license": "MIT"
     },
     "node_modules/@agentage/observability": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@agentage/observability/-/observability-0.6.1.tgz",
-      "integrity": "sha512-eaMeZqeu+pITlaWMg0dzN2LQCqoTQQAzteF/fejv2Jlv5kqUnW9AR8DZqQRSFQnFJa8ibV37zjNxshHfOTCiWQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@agentage/observability/-/observability-0.6.2.tgz",
+      "integrity": "sha512-0majcV+z1GWJ5D9ANjXeCxvrGea0e7z0qafwJfD7bmvHvT1K1lsqIp9sviPVRDgEgj5fj6fyDOxOFNuSfFd8QA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",


### PR DESCRIPTION
Bumps @agentage/observability lockfile pin 0.6.1 -> 0.6.2 (RSC span fold now lands at span end, matching Next's server-span naming at END).