### PR TITLE
feat: add estate-standard /health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 
+# ARGs don't cross stage boundaries; redeclare so /health reads real provenance
+# at runtime instead of the kit's 0.0.0-dev/dev fallback.
+ARG COMMIT_SHA="" BUILD_TIME=""
+ENV COMMIT_SHA=$COMMIT_SHA
+ENV BUILD_TIME=$BUILD_TIME
+
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
           memory: 128M
 
     healthcheck:
-      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://127.0.0.1:3000/']
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://127.0.0.1:3000/health']
       interval: 30s
       timeout: 10s
       retries: 3

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "@agentage/observability": "^0.6.1",
+        "@agentage/observability": "^0.8.0",
         "@chemistry/crystalview": "^3.0.0",
         "@chemistry/molpad": "^3.1.0",
         "@vercel/otel": "^2.1.3",
@@ -71,9 +71,9 @@
       "license": "MIT"
     },
     "node_modules/@agentage/observability": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@agentage/observability/-/observability-0.6.2.tgz",
-      "integrity": "sha512-0majcV+z1GWJ5D9ANjXeCxvrGea0e7z0qafwJfD7bmvHvT1K1lsqIp9sviPVRDgEgj5fj6fyDOxOFNuSfFd8QA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@agentage/observability/-/observability-0.8.1.tgz",
+      "integrity": "sha512-haJ2YFpLigtHlnKOp93y6c0PWFudn9izuzRioffYadJjNTzy/Ovg/7DI943bXANAW4iYbK3MAlJYT3qmxa521Q==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:e2e:ui": "npx playwright test --ui"
   },
   "dependencies": {
-    "@agentage/observability": "^0.6.1",
+    "@agentage/observability": "^0.8.0",
     "@chemistry/crystalview": "^3.0.0",
     "@chemistry/molpad": "^3.1.0",
     "@vercel/otel": "^2.1.3",

--- a/src/app/health/route.test.ts
+++ b/src/app/health/route.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { GET } from './route';
+
+describe('GET /health', () => {
+  // Mirrors deploy.yml's runtime .env, so the kit's default service resolution
+  // (OTEL_SERVICE_NAME) is exercised the same way it is in production.
+  beforeEach(() => {
+    process.env.OTEL_SERVICE_NAME = 'vreshch-web';
+  });
+
+  afterEach(() => {
+    delete process.env.OTEL_SERVICE_NAME;
+  });
+
+  it('returns the v1 health envelope for vreshch-web', async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.service).toBe('vreshch-web');
+    expect(body.data.status).toBe('ok');
+  });
+});

--- a/src/app/health/route.ts
+++ b/src/app/health/route.ts
@@ -1,0 +1,10 @@
+import { healthResponse } from '@agentage/observability/health';
+
+// Never prerender, or commit/buildTime are baked at build instead of read from the
+// running container.
+export const dynamic = 'force-dynamic';
+
+// No explicit `service`: deploy.yml writes OTEL_SERVICE_NAME=vreshch-web to the
+// runtime .env (consumed via docker-compose's env_file), so the kit's default
+// keeps this route and telemetry service.name equal by construction.
+export const GET = () => healthResponse();


### PR DESCRIPTION
## Summary

Adds the estate-standard `/health` contract (`/home/vreshch/vaults/agentage/specs/health-endpoints.md`) to vreshch.com. Today `https://vreshch.com/health` 404s; without it, admin.agentage.io can only show "No probe" for this service.

- Bumped `@agentage/observability` `^0.6.1` -> `^0.8.0` (already a dependency for OTEL tracing via `/next`; this adds the `/health` subpath, which is dependency-free - no OpenTelemetry pulled into the route).
- `src/app/health/route.ts` - `export const dynamic = 'force-dynamic'` + `healthResponse()`, per the Next.js profile in the spec (SSR shell, no downstream dependency checks).
- `Dockerfile` - runner stage now redeclares `ARG COMMIT_SHA/BUILD_TIME` and promotes them to `ENV`, since ARGs don't cross stage boundaries and the envelope reads build provenance from runtime env vars. Without this it would report `0.0.0-dev`/`dev` forever.
- `docker-compose.yml` - Swarm healthcheck now spiders `/health` instead of `/` (see judgement call below).

## Judgement calls

1. **No explicit `service` param.** The route calls `healthResponse()` with no override. `.github/workflows/deploy.yml` writes `OTEL_SERVICE_NAME=vreshch-web` into the runtime `.env` (consumed via `docker-compose.yml`'s `env_file: .env`), and the kit's `resolveServiceName` defaults to `OTEL_SERVICE_NAME`. Confirmed this end-to-end with a local container run: `-e OTEL_SERVICE_NAME=vreshch-web` produces `"service": "vreshch-web"`; without it, `"service": "unknown"` (loud on purpose, per the kit's docstring). This is deliberate: it keeps the health `service` and the OTEL `service.name` equal by construction instead of by two hand-typed strings drifting apart, which is the exact defect (H hand-typed mismatch) the spec calls out in 9 of 10 services today. Trade-off: a container run outside this deploy pipeline (e.g. local `docker run` without the prod `.env`) will report `service: "unknown"` rather than `vreshch-web` - acceptable since this repo has no preview environment (direct-to-prod).
2. **`docker-compose.yml` healthcheck moved from `/` to `/health`.** Recommended and made the change: `/` renders the full homepage (blog list, images) so a content-only regression or a slow render can flap the Swarm health state for reasons unrelated to "is the process alive"; `/health` is the minimal, stable, estate-standard surface built for exactly this and won't shift when the homepage changes. Also lines up the container's own healthcheck with what admin.agentage.io will be probing externally.
3. **No dependency checks added** - per the spec's Next.js profile, an SSR shell must not probe downstream services, and vreshch.com has none server-side anyway.

## Verification

- `npm run verify` (type-check + lint + build + test) - green, `/health` builds as `ƒ` (dynamic).
- `npm run format:check` - green (separate CI step, not part of `verify` in this repo).
- Built the container with `--build-arg COMMIT_SHA=testsha1234567890 --build-arg BRANCH=feature/health-endpoint --build-arg BUILD_TIME=2026-08-09T12:00:00Z`, ran it, and curled `/health`:
  ```json
  {
    "success": true,
    "data": {
      "status": "ok",
      "service": "unknown",
      "version": "testsha1234567890",
      "commit": "testsha",
      "buildTime": "2026-08-09T12:00:00Z",
      "startedAt": "2026-08-09T14:34:12.819Z",
      "uptimeSeconds": 7
    }
  }
  ```
  `commit` is 7 chars, `version` is the full sha, `buildTime` round-trips - confirms the Dockerfile ARG-to-ENV promotion works. `service` reads `unknown` here because this ad-hoc `docker run` didn't set `OTEL_SERVICE_NAME` (not baked into the image, only written to the server's `.env` by the deploy job). Re-ran with `-e OTEL_SERVICE_NAME=vreshch-web` and got `"service": "vreshch-web"`, matching what prod will report.
- Added `src/app/health/route.test.ts` (Vitest) asserting 200, `success: true`, `data.service === 'vreshch-web'`, `data.status === 'ok'` (stubs `OTEL_SERVICE_NAME` to mirror the prod runtime env).

## Test plan

- [ ] CI green (`pr-validation.yml` including the separate Format check step)
- [ ] After merge + deploy, `curl https://vreshch.com/health` returns the envelope with `service: "vreshch-web"` and real `commit`/`buildTime`
- [ ] admin.agentage.io Services page picks up a probe for vreshch-web instead of "No probe"
