### PR TITLE
ci: offset train cron and dependabot time off :00 for host stagger

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'friday'
-      time: '18:00'
+      time: '16:07'
       timezone: 'Europe/Prague'
     assignees:
       - 'vreshch'
@@ -23,7 +23,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'friday'
-      time: '18:00'
+      time: '16:07'
       timezone: 'Europe/Prague'
     assignees:
       - 'vreshch'
@@ -38,7 +38,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'friday'
-      time: '18:00'
+      time: '16:07'
       timezone: 'Europe/Prague'
     assignees:
       - 'vreshch'

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -4,7 +4,7 @@ name: Train
 # Red run = the only alarm; there are no silent-skip states.
 on:
   schedule:
-    - cron: '0 21 * * 5'
+    - cron: '17 21 * * 5'
   workflow_dispatch:
     inputs:
       bump_deps:


### PR DESCRIPTION
## Summary
- Scheduling rule change: no cron at minute :00, and same-host deploys staggered 10 min apart (vreshch.com shares the host with crystallography.io + diffractwd.com).
- `train.yml` cron: `0 21 * * 5` -> `17 21 * * 5`.
- `dependabot.yml` time for all 3 ecosystems (npm, docker, github-actions): `18:00` -> `16:07`.

## Test plan
- [x] YAML syntax valid (`yaml.safe_load`)
- [x] `npx @action-validator/cli` clean on train.yml
- [x] `npm run format:check` / prettier clean
- [ ] CI green on this PR (pr-validation.yml)