### PR TITLE
ci: dependabot timezone Europe/Prague -> Etc/UTC (estate standard)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: 'weekly'
       day: 'friday'
       time: '16:07'
-      timezone: 'Europe/Prague'
+      timezone: 'Etc/UTC'
     assignees:
       - 'vreshch'
     open-pull-requests-limit: 10
@@ -24,7 +24,7 @@ updates:
       interval: 'weekly'
       day: 'friday'
       time: '16:07'
-      timezone: 'Europe/Prague'
+      timezone: 'Etc/UTC'
     assignees:
       - 'vreshch'
     open-pull-requests-limit: 5
@@ -39,7 +39,7 @@ updates:
       interval: 'weekly'
       day: 'friday'
       time: '16:07'
-      timezone: 'Europe/Prague'
+      timezone: 'Etc/UTC'
     assignees:
       - 'vreshch'
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Estate standard: dependabot schedule timezone is Etc/UTC everywhere, so the configured time is the literal UTC time.
- `dependabot.yml` was still on `timezone: 'Europe/Prague'`, so `time: '16:07'` meant 14:07 UTC (CEST, UTC+2), not 16:07 UTC as intended by the prior cron-offset PR.
- All 3 ecosystems (npm, docker, github-actions) switched to `timezone: 'Etc/UTC'`; `time: '16:07'` unchanged, now literally 16:07 UTC.

## Test plan
- [x] YAML syntax valid
- [x] `npm run format:check` / prettier clean
- [ ] CI green on this PR (pr-validation.yml)